### PR TITLE
Update local.conf QT Enablement

### DIFF
--- a/conf/rzboard/local.conf
+++ b/conf/rzboard/local.conf
@@ -30,6 +30,9 @@ VIRTUAL-RUNTIME_init_manager = "systemd"
 
 SDKIMAGE_FEATURES_append = " staticdev-pkgs dev-pkgs dbg-pkgs"
 
+# Uncomment the following if interested in QT demo enablement
+# QT_DEMO = "1"
+
 DISTRO_FEATURES_append = " pam"
 DISTRO_FEATURES_append = " wayland"
 DISTRO_FEATURES_remove = " x11"


### PR DESCRIPTION
It wasn't clear before how to enable QT demos (unless you've already stumbled through tons of documentation): https://www.hackster.io/lucas-keller/build-deploy-run-a-qt-enabled-image-on-the-rzboard-v2l-de6c41