### PR TITLE
Update Multi-OS, AI package links

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ The following packages should be download:
 | RZ/V Verified Linux Package   | V3.0.6            | [RTK0EF0045Z0024AZJ-v3.0.6.zip](https://www.renesas.com/en/document/swo/rzv-verified-linux-package-v306rtk0ef0045z0024azj-v306zip?r=1628526) |
 | RZ MPU Graphics Library       | Evaluation Version V1.2.2 | [RTK0EF0045Z13001ZJ-v1.2.2_EN.zip](https://www.renesas.com/us/en/document/swo/rz-mpu-graphics-library-evaluation-version-v122-rzg2l-rzg2lc-and-rzv2l-rtk0ef0045z13001zj-v122xxzip?language=en&r=1843541) |
 | RZ MPU Codec Library          | Evaluation Version V1.2.2 | [RTK0EF0045Z15001ZJ-v1.2.2_EN.zip](https://www.renesas.com/us/en/document/swo/rz-mpu-video-codec-library-evaluation-version-v122-rzg2l-and-rzv2l-rtk0ef0045z15001zj-v122xxzip?language=en&r=1844066) |
-| RZ/V2L DRP-AI Support Package | V7.50                     | [r11an0549ej0750-rzv2l-drpai-sp.zip](https://www.renesas.com/en/document/swo/drp-ai-open-source-packageosspkgrzvdrpaiv7507z) |
-| RZ/V2L Multi-OS Package       | V2.0.0                   | [r01an7254ej0200-rzv2l-multi-os-pkg.zip](https://www.renesas.com/us/en/document/sws/rzv-multi-os-package-v200?language=en&r=1570181) |
+| RZ/V2L DRP-AI Support Package | V7.50                     | [r11an0549ej0750-rzv2l-drpai-sp.zip](https://www.renesas.com/en/document/sws/rzv2l-drp-ai-support-package-version-750?r=1558356) |
+| RZ/V2L Multi-OS Package       | V2.0.0                   | [r01an7254ej0200-rzv2l-multi-os-pkg.zip](https://www.renesas.com/en/document/sws/rzv-multi-os-package-v210?r=1570181) |
 
 > ***Note***:   
 > *1  The Renesas website provides two version packages, "**Evaluation Version**" and "**Unrestricted Version**", for each of the RZ MPU Graphics Library and the RZ MPU Codec Library.*  

--- a/tools/create_yocto_rz_src.sh
+++ b/tools/create_yocto_rz_src.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=0.4.0
+VERSION=0.4.1
 
 # Make sure that the following packages have been downloaded from the official website
 # RZ/V Verified Linux Package [5.10-CIP]  V3.0.6
@@ -20,9 +20,8 @@ REN_VEDIO_CODEC_LIB_PKG_EVAL="RTK0EF0045Z15001ZJ-v1.2.2_EN"
 # RZ/V2L DRP-AI Support Package Version 7.50
 REN_V2L_DRPAI_PKG="r11an0549ej0750-rzv2l-drpai-sp"
 
-# RZ/V2L Multi-OS Package V1.20
-REN_V2L_MULTI_OS_PKG="r01an7254ej0200_rzv-multi-os-pkg"
-                   
+# RZ/V2L Multi-OS Package V2.1.0
+REN_V2L_MULTI_OS_PKG="r01an7254ej0210_rzv-multi-os-pkg"
 # ----------------------------------------------------------------
 
 WORKSPACE=$(pwd)


### PR DESCRIPTION
# Documentation / automation improvements

Just some link cleanup. Feel free to double check these.

- "r01an7254ej0200_rzv-multi-os-pkg" Isnt hosted anymore -> update to r01an7254ej0210_rzv-multi-os-pkg
- Fixed DRP-AI Support Package Link: (https://www.renesas.com/en/document/sws/rzv2l-drp-ai-support-package-version-750?r=1558356) to download r11an0549ej0750-rzv2l-drpai-sp.zip instead of full 7GB OSS file.