### PR TITLE
Update flash utility version

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ The following packages should be download:
 | RZ/V Verified Linux Package   | V3.0.6            | [RTK0EF0045Z0024AZJ-v3.0.6.zip](https://www.renesas.com/en/document/swo/rzv-verified-linux-package-v306rtk0ef0045z0024azj-v306zip?r=1628526) |
 | RZ MPU Graphics Library       | Evaluation Version V1.2.2 | [RTK0EF0045Z13001ZJ-v1.2.2_EN.zip](https://www.renesas.com/us/en/document/swo/rz-mpu-graphics-library-evaluation-version-v122-rzg2l-rzg2lc-and-rzv2l-rtk0ef0045z13001zj-v122xxzip?language=en&r=1843541) |
 | RZ MPU Codec Library          | Evaluation Version V1.2.2 | [RTK0EF0045Z15001ZJ-v1.2.2_EN.zip](https://www.renesas.com/us/en/document/swo/rz-mpu-video-codec-library-evaluation-version-v122-rzg2l-and-rzv2l-rtk0ef0045z15001zj-v122xxzip?language=en&r=1844066) |
-| RZ/V2L DRP-AI Support Package | V7.50                     | [r11an0549ej0750-rzv2l-drpai-sp.zip](https://www.renesas.com/en/document/swo/drp-ai-open-source-packageosspkgrzvdrpaiv7507z) |
-| RZ/V2L Multi-OS Package       | V2.0.0                   | [r01an7254ej0200-rzv2l-multi-os-pkg.zip](https://www.renesas.com/us/en/document/sws/rzv-multi-os-package-v200?language=en&r=1570181) |
+| RZ/V2L DRP-AI Support Package | V7.50                     | [r11an0549ej0750-rzv2l-drpai-sp.zip](https://www.renesas.com/en/document/sws/rzv2l-drp-ai-support-package-version-750?r=1558356) |
+| RZ/V2L Multi-OS Package       | V2.0.0                   | [r01an7254ej0200-rzv2l-multi-os-pkg.zip](https://www.renesas.com/en/document/sws/rzv-multi-os-package-v210?r=1570181) |
 
 > ***Note***:   
 > *1  The Renesas website provides two version packages, "**Evaluation Version**" and "**Unrestricted Version**", for each of the RZ MPU Graphics Library and the RZ MPU Codec Library.*  

--- a/conf/rzboard/local.conf
+++ b/conf/rzboard/local.conf
@@ -30,6 +30,9 @@ VIRTUAL-RUNTIME_init_manager = "systemd"
 
 SDKIMAGE_FEATURES_append = " staticdev-pkgs dev-pkgs dbg-pkgs"
 
+# Uncomment the following if interested in QT demo enablement
+# QT_DEMO = "1"
+
 DISTRO_FEATURES_append = " pam"
 DISTRO_FEATURES_append = " wayland"
 DISTRO_FEATURES_remove = " x11"

--- a/recipes-core/images/avnet-core-image.bb
+++ b/recipes-core/images/avnet-core-image.bb
@@ -8,6 +8,7 @@ IMAGE_INSTALL_append = " \
     "
 
 # Package up images to release
+# Call with bitbake avnet-core-image -c release
 do_release() {
     # Variables
     RZ_IMAGES_DIR=${DEPLOY_DIR}/images/rzboard
@@ -27,12 +28,18 @@ do_release() {
     cp ${RZ_IMAGES_DIR}/bl2_bp-rzboard.srec ${RELEASE_DIR}
     cp ${RZ_IMAGES_DIR}/Flash_Writer_SCIF_rzboard.mot ${RELEASE_DIR}
     cp ${RZ_IMAGES_DIR}/avnet-core-image-rzboard.wic ${RELEASE_DIR}
+
+    # Flash util essentials
     cp ${RZ_IMAGES_DIR}/requirements.txt ${RELEASE_DIR}
-    cp ${RZ_IMAGES_DIR}/flash_util.py ${RELEASE_DIR}
+    cp -r ${RZ_IMAGES_DIR}/flash_utils ${RELEASE_DIR}
+    cp ${RZ_IMAGES_DIR}/flash_rzboard.py ${RELEASE_DIR}
     cp ${RZ_IMAGES_DIR}/adb/*.zip ${RELEASE_DIR}/adb
+
     cp ${RZ_IMAGES_DIR}/avnet-core-image-rzboard.manifest ${RELEASE_DIR}/
 
     tar -zcf ${RZ_IMAGES_DIR}/release.tar.gz -C ${RZ_IMAGES_DIR} release
+
+    bbnote "Release package created at ${RZ_IMAGES_DIR}/release.tar.gz"
 }
 
 addtask release

--- a/recipes-support/flash-utility/flash-utility_1.0.bb
+++ b/recipes-support/flash-utility/flash-utility_1.0.bb
@@ -5,9 +5,8 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 SRC_URI = "git://github.com/avnet/rzboard_flash_util.git;branch=main;"
 
-# Modify these as desired
-PV = "1.0.0+git${SRCPV}"
-SRCREV = "2d6b78c42330fffbd0b045dce473e5aaa6026fcc"
+PV = "1.0.1+git${SRCPV}"
+SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 

--- a/tools/create_yocto_rz_src.sh
+++ b/tools/create_yocto_rz_src.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=0.4.0
+VERSION=0.4.1
 
 # Make sure that the following packages have been downloaded from the official website
 # RZ/V Verified Linux Package [5.10-CIP]  V3.0.6
@@ -20,9 +20,8 @@ REN_VEDIO_CODEC_LIB_PKG_EVAL="RTK0EF0045Z15001ZJ-v1.2.2_EN"
 # RZ/V2L DRP-AI Support Package Version 7.50
 REN_V2L_DRPAI_PKG="r11an0549ej0750-rzv2l-drpai-sp"
 
-# RZ/V2L Multi-OS Package V1.20
-REN_V2L_MULTI_OS_PKG="r01an7254ej0200_rzv-multi-os-pkg"
-                   
+# RZ/V2L Multi-OS Package V2.1.0
+REN_V2L_MULTI_OS_PKG="r01an7254ej0210_rzv-multi-os-pkg"
 # ----------------------------------------------------------------
 
 WORKSPACE=$(pwd)


### PR DESCRIPTION
## Justification

Because the flash utility has CI, we should be safe to autoinc software versions. Especially considering that the flash utility should be updated with RZBoard releases as it will become out of date without autoinc.

## Testing

I've tested building, unpacking, and deploying the release.tar.gz.

Building:
`bitbake avnet-core-image -c release`,

Deploying:
`python flash_rzboard.py --full --static_ip 169.254.1.2`
(I utilize my secondary ethernet port on my linux machine for the 169.254. subnet. The automatic IP handshaking tends not to work for me on Linux)

### Versioning
Ubuntu 20.04 / Python 3.12.3
