### PR TITLE
Feature/node 18 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This is a meta-layer for Avnet RzBoard.
 - Yocto dunfell 3.1.31 support:  Avnet RzBoard
 
 
-
 ## How to Build
 
 
@@ -28,7 +27,6 @@ Set Git configuration:
 $ git config --global user.name "Your Name"
 $ git config --global user.email "you@example.com"
 ```
-
 
 
 ### Fetch the source code
@@ -70,45 +68,17 @@ $ ls ~/
 create_yocto_rz_src.sh                       RTK0EF0045Z0024AZJ-v3.0.6.zip
 r01an7254ej0200-rzv-multi-os-pkg.zip         RTK0EF0045Z13001ZJ-v1.2.2_EN.zip
 r11an0549ej0750-rzv2l-drpai-sp.zip           RTK0EF0045Z15001ZJ-v1.2.2_EN.zip
+
 ```
-Run the script to generate **yocto_rzboard/** directory
+Run the script to generate **yocto_rzboard/** directory which contains all the necessary sources. This script will verify, extract, and patch essential files.
 ```bash
 $ ./create_yocto_rz_src.sh
 $ ls yocto_rzboard/
 extra  meta-gplv2         meta-qt5      meta-rz-features     poky
-meta-openembedded  meta-renesas  meta-virtualization      
+meta-openembedded  meta-renesas  meta-virtualization         RZV2L_VLP306_switch_to_nodejs_18.17.1.patch
 ```
-
-
-
-* ##### **Download meta-rzboard**
-
-```bash
-$ cd ~/yocto_rzboard
-$ git clone https://github.com/Avnet/meta-rzboard.git -b rzboard_dunfell_5.10.201
-```
-
-So far, all the yocto related sources are in place.
-
-```bash
-$ ls ~/yocto_rzboard
-meta-gplv2         meta-qt5      meta-rz-features  meta-virtualization
-meta-openembedded  meta-renesas  meta-rzboard      poky
-```
-
-
 
 ### Build a image
-
-*  ##### **Create build configuration**
-
-```bash
-$ cd ~/yocto_rzboard
-$ mkdir -p ./build/conf
-$ cp meta-rzboard/conf/rzboard/* build/conf/
-$ ls build/conf/
-bblayers.conf  local.conf  site.conf
-```
 
 *  ##### **Build**
 ```bash

--- a/recipes-core/images/avnet-core-image.bb
+++ b/recipes-core/images/avnet-core-image.bb
@@ -7,6 +7,12 @@ IMAGE_INSTALL_append = " \
     nodejs-npm \
     "
 
+# Wildcard to preferred version of nodejs to 14.x, as this version is
+# provided in meta-oe. 
+# Prefer higher versions compatible with Edge Impulse (we will want to bump this with future yocto updates)
+PREFERRED_VERSION_nodejs = "14.%"
+PREFERRED_VERSION_nodejs-npm = "14.%"
+
 # Package up images to release
 # Call with bitbake avnet-core-image -c release
 do_release() {

--- a/recipes-core/images/core-image.inc
+++ b/recipes-core/images/core-image.inc
@@ -74,7 +74,6 @@ IMAGE_INSTALL_append = " \
 	drpai-app-demos \
 	usb-camera-http-demo \
 	rzboard-app-script \
-	rzboard-demo-launcher \
 "
 
 unzip_drpai_demo() {

--- a/recipes-qt/qtwebkit/0001-fix-true-false-textbreakiterator.patch
+++ b/recipes-qt/qtwebkit/0001-fix-true-false-textbreakiterator.patch
@@ -1,0 +1,79 @@
+--- a/Source/WebCore/platform/text/TextBreakIteratorICU.cpp
++++ b/Source/WebCore/platform/text/TextBreakIteratorICU.cpp
+@@ -214,12 +214,12 @@
+             // Ensure chunk offset is well formed if computed offset exceeds int32_t range.
+             ASSERT(offset < numeric_limits<int32_t>::max());
+             text->chunkOffset = offset < numeric_limits<int32_t>::max() ? static_cast<int32_t>(offset) : 0;
+-            isAccessible = TRUE;
++            isAccessible = true;
+             return true;
+         }
+         if (nativeIndex >= nativeLength && text->chunkNativeLimit == nativeLength) {
+             text->chunkOffset = text->chunkLength;
+-            isAccessible = FALSE;
++            isAccessible = false;
+             return true;
+         }
+     } else {
+@@ -228,12 +228,12 @@
+             // Ensure chunk offset is well formed if computed offset exceeds int32_t range.
+             ASSERT(offset < numeric_limits<int32_t>::max());
+             text->chunkOffset = offset < numeric_limits<int32_t>::max() ? static_cast<int32_t>(offset) : 0;
+-            isAccessible = TRUE;
++            isAccessible = true;
+             return true;
+         }
+         if (nativeIndex <= 0 && !text->chunkNativeStart) {
+             text->chunkOffset = 0;
+-            isAccessible = FALSE;
++            isAccessible = false;
+             return true;
+         }
+     }
+@@ -243,7 +243,7 @@
+ static UBool textLatin1Access(UText* text, int64_t nativeIndex, UBool forward)
+ {
+     if (!text->context)
+-        return FALSE;
++        return false;
+     int64_t nativeLength = textNativeLength(text);
+     UBool isAccessible;
+     if (textInChunkOrOutOfRange(text, nativeIndex, nativeLength, forward, isAccessible))
+@@ -263,7 +263,7 @@
+         ASSERT(newContext == PriorContext);
+         textLatin1SwitchToPriorContext(text, nativeIndex, nativeLength, forward);
+     }
+-    return TRUE;
++    return true;
+ }
+ 
+ static const struct UTextFuncs textLatin1Funcs = {
+@@ -364,7 +364,7 @@
+ static UBool textUTF16Access(UText* text, int64_t nativeIndex, UBool forward)
+ {
+     if (!text->context)
+-        return FALSE;
++        return false;
+     int64_t nativeLength = textNativeLength(text);
+     UBool isAccessible;
+     if (textInChunkOrOutOfRange(text, nativeIndex, nativeLength, forward, isAccessible))
+@@ -384,7 +384,7 @@
+         ASSERT(newContext == PriorContext);
+         textUTF16SwitchToPriorContext(text, nativeIndex, nativeLength, forward);
+     }
+-    return TRUE;
++    return true;
+ }
+ 
+ static const struct UTextFuncs textUTF16Funcs = {
+--- a/Source/WebCore/platform/text/TextCodecICU.cpp.orig
++++ b/Source/WebCore/platform/text/TextCodecICU.cpp
+@@ -269,7 +269,7 @@
+     m_converterICU = ucnv_open(m_canonicalConverterName, &err);
+     ASSERT(U_SUCCESS(err));
+     if (m_converterICU)
+-        ucnv_setFallback(m_converterICU, TRUE);
++        ucnv_setFallback(m_converterICU, true);
+ }
+ 
+ int TextCodecICU::decodeToBuffer(UChar* target, UChar* targetLimit, const char*& source, const char* sourceLimit, int32_t* offsets, bool flush, UErrorCode& err)

--- a/recipes-qt/qtwebkit_git.bbappend
+++ b/recipes-qt/qtwebkit_git.bbappend
@@ -1,0 +1,7 @@
+# Revision for qt5.6.3
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "\
+    file://0001-fix-true-false-textbreakiterator.patch \
+"

--- a/tools/RZV2L_VLP306_switch_to_nodejs_18.17.1.patch
+++ b/tools/RZV2L_VLP306_switch_to_nodejs_18.17.1.patch
@@ -1,0 +1,15143 @@
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-Disable-running-gyp-files-for-bundled-deps-nodejs14.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-Disable-running-gyp-files-for-bundled-deps-nodejs14.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-Disable-running-gyp-files-for-bundled-deps-nodejs14.patch	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-Disable-running-gyp-files-for-bundled-deps-nodejs14.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,22 +0,0 @@
+-From 7d94bfe53beeb2d25eb5f2ff6b1d509df7e6ab80 Mon Sep 17 00:00:00 2001
+-From: Zuzana Svetlikova <zsvetlik@redhat.com>
+-Date: Thu, 27 Apr 2017 14:25:42 +0200
+-Subject: [PATCH] Disable running gyp on shared deps
+-
+----
+- Makefile | 2 +-
+- 1 file changed, 1 insertion(+), 1 deletion(-)
+-
+-diff --git a/Makefile b/Makefile
+-index 93d63110..79caaec2 100644
+---- a/Makefile
+-+++ b/Makefile
+-@@ -138,7 +138,7 @@ with-code-cache test-code-cache:
+-	$(warning '$@' target is a noop)
+-
+- out/Makefile: config.gypi common.gypi node.gyp \
+--	deps/uv/uv.gyp deps/llhttp/llhttp.gyp deps/zlib/zlib.gyp \
+-+	deps/llhttp/llhttp.gyp \
+-	tools/v8_gypfiles/toolchain.gypi tools/v8_gypfiles/features.gypi \
+-	tools/v8_gypfiles/inspector.gypi tools/v8_gypfiles/v8.gyp
+-	$(PYTHON) tools/gyp_node.py -f make
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-Disable-running-gyp-files-for-bundled-deps.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-Disable-running-gyp-files-for-bundled-deps.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-Disable-running-gyp-files-for-bundled-deps.patch	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-Disable-running-gyp-files-for-bundled-deps.patch	2024-08-02 09:22:58.247987887 +0200
+@@ -1,25 +1,46 @@
+-From c2aff16cc196a61f4ab1cdae4a91c7926123c239 Mon Sep 17 00:00:00 2001
++From 7d94bfe53beeb2d25eb5f2ff6b1d509df7e6ab80 Mon Sep 17 00:00:00 2001
+ From: Zuzana Svetlikova <zsvetlik@redhat.com>
+ Date: Thu, 27 Apr 2017 14:25:42 +0200
+ Subject: [PATCH] Disable running gyp on shared deps
+ 
++Upstream-Status: Inappropriate [embedded specific]
++
++Probably imported from:
++https://src.fedoraproject.org/rpms/nodejs/c/41af04f2a3c050fb44628e91ac65fd225b927acb?branch=22609d8c1bfeaa21fe0057645af20b3a2ccc7f53
++which is probably based on dont-run-gyp-files-for-bundled-deps.patch added in:
++https://github.com/alpinelinux/aports/commit/6662eb3199902e8451fb20dce82554ad96f796bb
++
++We also explicitly prune some dependencies from source in the bitbake recipe:
++
++python prune_sources() {
++    import shutil
++
++    shutil.rmtree(d.getVar('S') + '/deps/openssl')
++    if 'ares' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/cares')
++    if 'brotli' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/brotli')
++    if 'libuv' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/uv')
++    if 'nghttp2' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/nghttp2')
++    if 'zlib' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/zlib')
++}
++do_unpack[postfuncs] += "prune_sources"
++
+ ---
+  Makefile | 2 +-
+  1 file changed, 1 insertion(+), 1 deletion(-)
+ 
+-diff --git a/Makefile b/Makefile
+-index 0947300f24..6c98691984 100644
+ --- a/Makefile
+ +++ b/Makefile
+-@@ -141,7 +141,7 @@ test-code-cache: with-code-cache
+- 	echo "'test-code-cache' target is a noop"
++@@ -169,7 +169,7 @@ with-code-cache test-code-cache:
++ 	$(warning '$@' target is a noop)
+  
+  out/Makefile: config.gypi common.gypi node.gyp \
+--	deps/uv/uv.gyp deps/http_parser/http_parser.gyp deps/zlib/zlib.gyp \
+-+	deps/http_parser/http_parser.gyp \
++-	deps/uv/uv.gyp deps/llhttp/llhttp.gyp deps/zlib/zlib.gyp \
+++	deps/llhttp/llhttp.gyp \
++ 	deps/simdutf/simdutf.gyp deps/ada/ada.gyp \
+  	tools/v8_gypfiles/toolchain.gypi tools/v8_gypfiles/features.gypi \
+  	tools/v8_gypfiles/inspector.gypi tools/v8_gypfiles/v8.gyp
+- 	$(PYTHON) tools/gyp_node.py -f make
+--- 
+-2.20.1
+-
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-jinja-tests.py-add-py-3.10-fix-nodejs14.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-jinja-tests.py-add-py-3.10-fix-nodejs14.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-jinja-tests.py-add-py-3.10-fix-nodejs14.patch	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-jinja-tests.py-add-py-3.10-fix-nodejs14.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,40 +0,0 @@
+-From e1d838089cd461d9efcf4d29d9f18f65994d2d6b Mon Sep 17 00:00:00 2001
+-From: Alexander Kanavin <alex@linutronix.de>
+-Date: Sun, 3 Oct 2021 22:48:39 +0200
+-Subject: [PATCH] jinja/tests.py: add py 3.10 fix
+-
+-Upstream-Status: Pending
+-Signed-off-by: Alexander Kanavin <alex@linutronix.de>
+----
+- deps/v8/third_party/jinja2/tests.py      | 2 +-
+- tools/inspector_protocol/jinja2/tests.py | 2 +-
+- 2 files changed, 2 insertions(+), 2 deletions(-)
+-
+-diff --git a/deps/v8/third_party/jinja2/tests.py b/deps/v8/third_party/jinja2/tests.py
+-index 0adc3d4..b14f85f 100644
+---- a/deps/v8/third_party/jinja2/tests.py
+-+++ b/deps/v8/third_party/jinja2/tests.py
+-@@ -10,7 +10,7 @@
+- """
+- import operator
+- import re
+--from collections import Mapping
+-+from collections.abc import Mapping
+- from jinja2.runtime import Undefined
+- from jinja2._compat import text_type, string_types, integer_types
+- import decimal
+-diff --git a/tools/inspector_protocol/jinja2/tests.py b/tools/inspector_protocol/jinja2/tests.py
+-index 0adc3d4..b14f85f 100644
+---- a/tools/inspector_protocol/jinja2/tests.py
+-+++ b/tools/inspector_protocol/jinja2/tests.py
+-@@ -10,7 +10,7 @@
+- """
+- import operator
+- import re
+--from collections import Mapping
+-+from collections.abc import Mapping
+- from jinja2.runtime import Undefined
+- from jinja2._compat import text_type, string_types, integer_types
+- import decimal
+---
+-2.20.1
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-liftoff-Correct-function-signatures.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-liftoff-Correct-function-signatures.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-liftoff-Correct-function-signatures.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-liftoff-Correct-function-signatures.patch	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,85 @@
++From dc3652c0abcdf8573fd044907b19d8eda7ca1124 Mon Sep 17 00:00:00 2001
++From: Khem Raj <raj.khem@gmail.com>
++Date: Wed, 20 Oct 2021 12:49:58 -0700
++Subject: [PATCH] [liftoff] Correct function signatures
++
++Fixes builds on mips where clang reports an error
++../deps/v8/src/wasm/baseline/mips/liftoff-assembler-mips.h:661:5: error: no matching member function for call to 'Move'
++    Move(tmp, src, type.value_type());
++    ^~~~
++
++Upstream-Status: Submitted [https://chromium-review.googlesource.com/c/v8/v8/+/3235674]
++
++Signed-off-by: Archana Polampalli <archana.polampalli@windriver.com>
++---
++ deps/v8/src/wasm/baseline/liftoff-assembler.h               | 6 +++---
++ deps/v8/src/wasm/baseline/mips/liftoff-assembler-mips.h     | 2 +-
++ deps/v8/src/wasm/baseline/mips64/liftoff-assembler-mips64.h | 2 +-
++ .../src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h   | 2 +-
++ 4 files changed, 6 insertions(+), 6 deletions(-)
++
++diff --git a/deps/v8/src/wasm/baseline/liftoff-assembler.h b/deps/v8/src/wasm/baseline/liftoff-assembler.h
++index 22c7f73a..db4cb168 100644
++--- a/deps/v8/src/wasm/baseline/liftoff-assembler.h
+++++ b/deps/v8/src/wasm/baseline/liftoff-assembler.h
++@@ -646,7 +646,7 @@ class LiftoffAssembler : public TurboAssembler {
++   void FinishCall(const ValueKindSig*, compiler::CallDescriptor*);
++ 
++   // Move {src} into {dst}. {src} and {dst} must be different.
++-  void Move(LiftoffRegister dst, LiftoffRegister src, ValueKind);
+++  void Move(LiftoffRegister dst, LiftoffRegister src, ValueKind kind);
++ 
++   // Parallel register move: For a list of tuples <dst, src, kind>, move the
++   // {src} register of kind {kind} into {dst}. If {src} equals {dst}, ignore
++@@ -795,8 +795,8 @@ class LiftoffAssembler : public TurboAssembler {
++   inline void MoveStackValue(uint32_t dst_offset, uint32_t src_offset,
++                              ValueKind);
++ 
++-  inline void Move(Register dst, Register src, ValueKind);
++-  inline void Move(DoubleRegister dst, DoubleRegister src, ValueKind);
+++  inline void Move(Register dst, Register src, ValueKind kind);
+++  inline void Move(DoubleRegister dst, DoubleRegister src, ValueKind kind);
++ 
++   inline void Spill(int offset, LiftoffRegister, ValueKind);
++   inline void Spill(int offset, WasmValue);
++diff --git a/deps/v8/src/wasm/baseline/mips/liftoff-assembler-mips.h b/deps/v8/src/wasm/baseline/mips/liftoff-assembler-mips.h
++index c76fd2f4..0fffe231 100644
++--- a/deps/v8/src/wasm/baseline/mips/liftoff-assembler-mips.h
+++++ b/deps/v8/src/wasm/baseline/mips/liftoff-assembler-mips.h
++@@ -661,7 +661,7 @@ void LiftoffAssembler::Store(Register dst_addr, Register offset_reg,
++     pinned = pinned | LiftoffRegList{dst_op.rm(), src};
++     LiftoffRegister tmp = GetUnusedRegister(src.reg_class(), pinned);
++     // Save original value.
++-    Move(tmp, src, type.value_type());
+++    Move(tmp, src, type.value_type().kind());
++ 
++     src = tmp;
++     pinned.set(tmp);
++diff --git a/deps/v8/src/wasm/baseline/mips64/liftoff-assembler-mips64.h b/deps/v8/src/wasm/baseline/mips64/liftoff-assembler-mips64.h
++index 36413545..48207337 100644
++--- a/deps/v8/src/wasm/baseline/mips64/liftoff-assembler-mips64.h
+++++ b/deps/v8/src/wasm/baseline/mips64/liftoff-assembler-mips64.h
++@@ -593,7 +593,7 @@ void LiftoffAssembler::Store(Register dst_addr, Register offset_reg,
++     pinned.set(dst_op.rm());
++     LiftoffRegister tmp = GetUnusedRegister(src.reg_class(), pinned);
++     // Save original value.
++-    Move(tmp, src, type.value_type());
+++    Move(tmp, src, type.value_type().kind());
++ 
++     src = tmp;
++     pinned.set(tmp);
++diff --git a/deps/v8/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h b/deps/v8/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
++index 642a7d2a..56ffcc2a 100644
++--- a/deps/v8/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
+++++ b/deps/v8/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
++@@ -589,7 +589,7 @@ void LiftoffAssembler::Store(Register dst_addr, Register offset_reg,
++     pinned.set(dst_op.rm());
++     LiftoffRegister tmp = GetUnusedRegister(src.reg_class(), pinned);
++     // Save original value.
++-    Move(tmp, src, type.value_type());
+++    Move(tmp, src, type.value_type().kind());
++ 
++     src = tmp;
++     pinned.set(tmp);
++--
++2.34.1
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-mips-Use-32bit-cast-for-operand-on-mips32.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-mips-Use-32bit-cast-for-operand-on-mips32.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-mips-Use-32bit-cast-for-operand-on-mips32.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-mips-Use-32bit-cast-for-operand-on-mips32.patch	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,34 @@
++From e65dde8db17da5acddeef7eb9316199c4e5e0811 Mon Sep 17 00:00:00 2001
++From: Khem Raj <raj.khem@gmail.com>
++Date: Tue, 19 Apr 2022 12:40:25 -0700
++Subject: [PATCH] mips: Use 32bit cast for operand on mips32
++
++Fixes
++deps/v8/src/compiler/backend/mips/code-generator-mips.cc: In member function 'void v8::internal::compiler::CodeGenerator::AssembleReturn(v8::internal::compiler::InstructionOperand*)':
++../deps/v8/src/compiler/backend/mips/code-generator-mips.cc:4233:48: error: call of overloaded 'Operand(int64_t)' is ambiguous
++ 4233 |                 Operand(static_cast<int64_t>(0)));
++      |                                                ^
++
++Upstream-Status: Pending
++
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++---
++ deps/v8/src/compiler/backend/mips/code-generator-mips.cc | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/deps/v8/src/compiler/backend/mips/code-generator-mips.cc b/deps/v8/src/compiler/backend/mips/code-generator-mips.cc
++index 2b8197e..b226140 100644
++--- a/deps/v8/src/compiler/backend/mips/code-generator-mips.cc
+++++ b/deps/v8/src/compiler/backend/mips/code-generator-mips.cc
++@@ -4230,7 +4230,7 @@ void CodeGenerator::AssembleReturn(InstructionOperand* additional_pop_count) {
++     } else if (FLAG_debug_code) {
++       __ Assert(eq, AbortReason::kUnexpectedAdditionalPopValue,
++                 g.ToRegister(additional_pop_count),
++-                Operand(static_cast<int64_t>(0)));
+++                Operand(static_cast<int32_t>(0)));
++     }
++   }
++   // Functions with JS linkage have at least one parameter (the receiver).
++-- 
++2.36.0
++
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-ppc64-Do-not-use-mminimal-toc-with-clang-nodejs14.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-ppc64-Do-not-use-mminimal-toc-with-clang-nodejs14.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-ppc64-Do-not-use-mminimal-toc-with-clang-nodejs14.patch	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-ppc64-Do-not-use-mminimal-toc-with-clang-nodejs14.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,27 +0,0 @@
+-From 0976af0f3b328436ea44a74a406f311adb2ab211 Mon Sep 17 00:00:00 2001
+-From: Khem Raj <raj.khem@gmail.com>
+-Date: Tue, 15 Jun 2021 19:01:31 -0700
+-Subject: [PATCH] ppc64: Do not use -mminimal-toc with clang
+-
+-clang does not support this option
+-
+-Signed-off-by: Khem Raj <raj.khem@gmail.com>
+----
+- common.gypi | 2 +-
+- 1 file changed, 1 insertion(+), 1 deletion(-)
+-
+-diff --git a/common.gypi b/common.gypi
+-index ee91fb1d..049c8f8c 100644
+---- a/common.gypi
+-+++ b/common.gypi
+-@@ -413,7 +413,7 @@
+-             'ldflags': [ '-m32' ],
+-           }],
+-           [ 'target_arch=="ppc64" and OS!="aix"', {
+--            'cflags': [ '-m64', '-mminimal-toc' ],
+-+            'cflags': [ '-m64' ],
+-             'ldflags': [ '-m64' ],
+-           }],
+-           [ 'target_arch=="s390x"', {
+---
+-2.32.0
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-ppc64-Do-not-use-mminimal-toc-with-clang.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-ppc64-Do-not-use-mminimal-toc-with-clang.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-ppc64-Do-not-use-mminimal-toc-with-clang.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-ppc64-Do-not-use-mminimal-toc-with-clang.patch	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,25 @@
++From 0976af0f3b328436ea44a74a406f311adb2ab211 Mon Sep 17 00:00:00 2001
++From: Khem Raj <raj.khem@gmail.com>
++Date: Tue, 15 Jun 2021 19:01:31 -0700
++Subject: [PATCH] ppc64: Do not use -mminimal-toc with clang
++
++clang does not support this option
++
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++---
++Upstream-Status: Pending
++
++ common.gypi | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++--- a/common.gypi
+++++ b/common.gypi
++@@ -417,7 +417,7 @@
++             'ldflags': [ '-m32' ],
++           }],
++           [ 'target_arch=="ppc64" and OS!="aix"', {
++-            'cflags': [ '-m64', '-mminimal-toc' ],
+++            'cflags': [ '-m64' ],
++             'ldflags': [ '-m64' ],
++           }],
++           [ 'target_arch=="s390x"', {
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-Remove-use-of-register-r7-because-llvm-now-issues-an.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-Remove-use-of-register-r7-because-llvm-now-issues-an.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-Remove-use-of-register-r7-because-llvm-now-issues-an.patch	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-Remove-use-of-register-r7-because-llvm-now-issues-an.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,53 +0,0 @@
+-From be8d3cd6eab4b8f9849133060abb1aba4400276b Mon Sep 17 00:00:00 2001
+-From: Amy Huang <akhuang@google.com>
+-Date: Thu, 23 Apr 2020 11:25:53 -0700
+-Subject: [PATCH] Remove use of register r7 because llvm now issues an error
+- when "r7" is used (starting in commit d85b3877)
+-
+-Bug: chromium:1073270
+-Change-Id: I7ec8112f170b98d2edaf92bc9341e738f8de07a3
+-Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2163435
+-Reviewed-by: Nico Weber <thakis@chromium.org>
+-Reviewed-by: Ross McIlroy <rmcilroy@chromium.org>
+-Commit-Queue: Nico Weber <thakis@chromium.org>
+-Cr-Commit-Position: refs/heads/master@{#67371}
+-Signed-off-by: Khem Raj <raj.khem@gmail.com>
+----
+-Upstream-Status: Backport [https://chromium.googlesource.com/v8/v8/+/00604cd2806b5d26bef592dd19989a234bd07a4b%5E%21/]
+- deps/v8/src/codegen/arm/cpu-arm.cc | 13 -------------
+- 1 file changed, 13 deletions(-)
+-
+-diff --git a/deps/v8/src/codegen/arm/cpu-arm.cc b/deps/v8/src/codegen/arm/cpu-arm.cc
+-index 868f360..654d68f 100644
+---- a/deps/v8/src/codegen/arm/cpu-arm.cc
+-+++ b/deps/v8/src/codegen/arm/cpu-arm.cc
+-@@ -30,18 +30,6 @@ V8_NOINLINE void CpuFeatures::FlushICache(void* start, size_t size) {
+-   register uint32_t end asm("r1") = beg + size;
+-   register uint32_t flg asm("r2") = 0;
+- 
+--#ifdef __clang__
+--  // This variant of the asm avoids a constant pool entry, which can be
+--  // problematic when LTO'ing. It is also slightly shorter.
+--  register uint32_t scno asm("r7") = __ARM_NR_cacheflush;
+--
+--  asm volatile("svc 0\n"
+--               :
+--               : "r"(beg), "r"(end), "r"(flg), "r"(scno)
+--               : "memory");
+--#else
+--  // Use a different variant of the asm with GCC because some versions doesn't
+--  // support r7 as an asm input.
+-   asm volatile(
+-       // This assembly works for both ARM and Thumb targets.
+- 
+-@@ -59,7 +47,6 @@ V8_NOINLINE void CpuFeatures::FlushICache(void* start, size_t size) {
+-       : "r"(beg), "r"(end), "r"(flg), [scno] "i"(__ARM_NR_cacheflush)
+-       : "memory");
+- #endif
+--#endif
+- #endif  // !USE_SIMULATOR
+- }
+- 
+--- 
+-2.29.2
+-
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-Using-native-binaries.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-Using-native-binaries.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-Using-native-binaries.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0001-Using-native-binaries.patch	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,77 @@
++From 6c3ac20477a4bac643088f24df3c042e627fafa9 Mon Sep 17 00:00:00 2001
++From: Guillaume Burel <guillaume.burel@stormshield.eu>
++Date: Fri, 3 Jan 2020 11:25:54 +0100
++Subject: [PATCH] Using native binaries
++
++Upstream-Status: Inappropriate [embedded specific]
++
++Originally added in:
++https://git.openembedded.org/meta-openembedded/commit/?id=1c8e4a679ae382f953b2e5c7a4966a4646314f3e
++later extended and renamed in:
++https://git.openembedded.org/meta-openembedded/commit/?id=feeb172d1a8bf010490d22b8df9448b20d9d2aed
++
++Signed-off-by: Archana Polampalli <archana.polampalli@windriver.com>
++---
++ node.gyp                 | 1 +
++ tools/v8_gypfiles/v8.gyp | 5 +++++
++ 2 files changed, 6 insertions(+)
++
++diff --git a/node.gyp b/node.gyp
++index e8e1d9f9..e60ccc10 100644
++--- a/node.gyp
+++++ b/node.gyp
++@@ -320,6 +320,7 @@
++                   'action_name': 'node_mksnapshot',
++                   'process_outputs_as_sources': 1,
++                   'inputs': [
+++                    '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
++                     '<(node_mksnapshot_exec)',
++                     '<(node_snapshot_main)',
++                   ],
++diff --git a/tools/v8_gypfiles/v8.gyp b/tools/v8_gypfiles/v8.gyp
++index 42e26cd9..bc721991 100644
++--- a/tools/v8_gypfiles/v8.gyp
+++++ b/tools/v8_gypfiles/v8.gyp
++@@ -68,6 +68,7 @@
++         {
++           'action_name': 'run_torque_action',
++           'inputs': [  # Order matters.
+++            '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
++             '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)torque<(EXECUTABLE_SUFFIX)',
++             '<@(torque_files)',
++           ],
++@@ -99,6 +100,7 @@
++             '<@(torque_outputs_inc)',
++           ],
++           'action': [
+++            '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
++             '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)torque<(EXECUTABLE_SUFFIX)',
++             '-o', '<(SHARED_INTERMEDIATE_DIR)/torque-generated',
++             '-v8-root', '<(V8_ROOT)',
++@@ -211,6 +213,7 @@
++         {
++           'action_name': 'generate_bytecode_builtins_list_action',
++           'inputs': [
+++            '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
++             '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)bytecode_builtins_list_generator<(EXECUTABLE_SUFFIX)',
++           ],
++           'outputs': [
++@@ -400,6 +403,7 @@
++             ],
++           },
++           'inputs': [
+++            '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
++             '<(mksnapshot_exec)',
++           ],
++           'outputs': [
++@@ -1539,6 +1543,7 @@
++         {
++           'action_name': 'run_gen-regexp-special-case_action',
++           'inputs': [
+++            '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
++             '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)gen-regexp-special-case<(EXECUTABLE_SUFFIX)',
++           ],
++           'outputs': [
++-- 
++2.34.1
++
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0002-Using-native-binaries-nodejs14.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0002-Using-native-binaries-nodejs14.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0002-Using-native-binaries-nodejs14.patch	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0002-Using-native-binaries-nodejs14.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,62 +0,0 @@
+-From 6c3ac20477a4bac643088f24df3c042e627fafa9 Mon Sep 17 00:00:00 2001
+-From: Guillaume Burel <guillaume.burel@stormshield.eu>
+-Date: Fri, 3 Jan 2020 11:25:54 +0100
+-Subject: [PATCH] Using native binaries
+-
+----
+- node.gyp                 |  4 ++--
+- tools/v8_gypfiles/v8.gyp | 11 ++++-------
+- 2 files changed, 6 insertions(+), 9 deletions(-)
+-
+---- a/node.gyp
+-+++ b/node.gyp
+-@@ -487,6 +487,7 @@
+-               'action_name': 'run_mkcodecache',
+-               'process_outputs_as_sources': 1,
+-               'inputs': [
+-+                '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
+-                 '<(mkcodecache_exec)',
+-               ],
+-               'outputs': [
+-@@ -512,6 +513,7 @@
+-               'action_name': 'node_mksnapshot',
+-               'process_outputs_as_sources': 1,
+-               'inputs': [
+-+                '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
+-                 '<(node_mksnapshot_exec)',
+-               ],
+-               'outputs': [
+---- a/tools/v8_gypfiles/v8.gyp
+-+++ b/tools/v8_gypfiles/v8.gyp
+-@@ -220,6 +220,7 @@
+-         {
+-           'action_name': 'run_torque_action',
+-           'inputs': [  # Order matters.
+-+            '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
+-             '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)torque<(EXECUTABLE_SUFFIX)',
+-             '<@(torque_files)',
+-           ],
+-@@ -351,6 +352,7 @@
+-         {
+-           'action_name': 'generate_bytecode_builtins_list_action',
+-           'inputs': [
+-+            '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
+-             '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)bytecode_builtins_list_generator<(EXECUTABLE_SUFFIX)',
+-           ],
+-           'outputs': [
+-@@ -533,6 +535,7 @@
+-             ],
+-           },
+-           'inputs': [
+-+            '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
+-             '<(mksnapshot_exec)',
+-           ],
+-           'outputs': [
+-@@ -1448,6 +1451,7 @@
+-         {
+-           'action_name': 'run_gen-regexp-special-case_action',
+-           'inputs': [
+-+            '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
+-             '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)gen-regexp-special-case<(EXECUTABLE_SUFFIX)',
+-           ],
+-           'outputs': [
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0002-Using-native-binaries.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0002-Using-native-binaries.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0002-Using-native-binaries.patch	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0002-Using-native-binaries.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,71 +0,0 @@
+-From 6c3ac20477a4bac643088f24df3c042e627fafa9 Mon Sep 17 00:00:00 2001
+-From: Guillaume Burel <guillaume.burel@stormshield.eu>
+-Date: Fri, 3 Jan 2020 11:25:54 +0100
+-Subject: [PATCH] Using native binaries
+-
+----
+- node.gyp                 |  4 ++--
+- tools/v8_gypfiles/v8.gyp | 11 ++++-------
+- 2 files changed, 6 insertions(+), 9 deletions(-)
+-
+-diff --git a/node.gyp b/node.gyp
+-index 8f4dc518..d9389190 100644
+---- a/node.gyp
+-+++ b/node.gyp
+-@@ -446,7 +446,7 @@
+-                 '<(SHARED_INTERMEDIATE_DIR)/node_code_cache.cc',
+-               ],
+-               'action': [
+--                '<@(_inputs)',
+-+                'mkcodecache',
+-                 '<@(_outputs)',
+-               ],
+-             },
+-@@ -471,7 +471,7 @@
+-                 '<(SHARED_INTERMEDIATE_DIR)/node_snapshot.cc',
+-               ],
+-               'action': [
+--                '<@(_inputs)',
+-+                'node_mksnapshot',
+-                 '<@(_outputs)',
+-               ],
+-             },
+-diff --git a/tools/v8_gypfiles/v8.gyp b/tools/v8_gypfiles/v8.gyp
+-index a506a67d..c91f7dde 100644
+---- a/tools/v8_gypfiles/v8.gyp
+-+++ b/tools/v8_gypfiles/v8.gyp
+-@@ -140,7 +140,8 @@
+-             '<@(torque_outputs)',
+-           ],
+-           'action': [
+--            '<@(_inputs)',
+-+            'torque',
+-+            '<@(torque_files)',
+-             '-o', '<(torque_output_root)/torque-generated',
+-             '-v8-root', '<(V8_ROOT)'
+-           ],
+-@@ -247,9 +248,7 @@
+-             '<(generate_bytecode_builtins_list_output)',
+-           ],
+-           'action': [
+--            'python',
+--            '<(V8_ROOT)/tools/run.py',
+--            '<@(_inputs)',
+-+            'bytecode_builtins_list_generator',
+-             '<@(_outputs)',
+-           ],
+-         },
+-@@ -1396,9 +1395,7 @@
+-             '<(SHARED_INTERMEDIATE_DIR)/src/regexp/special-case.cc',
+-           ],
+-           'action': [
+--            'python',
+--            '<(V8_ROOT)/tools/run.py',
+--            '<@(_inputs)',
+-+            'gen-regexp-special-case',
+-             '<@(_outputs)',
+-           ],
+-         },
+--- 
+-2.20.1
+-
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0003-Install-both-binaries-and-use-libdir-nodejs14.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0003-Install-both-binaries-and-use-libdir-nodejs14.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0003-Install-both-binaries-and-use-libdir-nodejs14.patch	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0003-Install-both-binaries-and-use-libdir-nodejs14.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,84 +0,0 @@
+-From 5b22fac923d1ca3e9fefb97f5a171124a88f5e22 Mon Sep 17 00:00:00 2001
+-From: Elliott Sales de Andrade <quantum.analyst@gmail.com>
+-Date: Tue, 19 Mar 2019 23:22:40 -0400
+-Subject: [PATCH] Install both binaries and use libdir.
+-MIME-Version: 1.0
+-Content-Type: text/plain; charset=UTF-8
+-Content-Transfer-Encoding: 8bit
+-
+-This allows us to build with a shared library for other users while
+-still providing the normal executable.
+-
+-Taken from - https://src.fedoraproject.org/rpms/nodejs/raw/rawhide/f/0002-Install-both-binaries-and-use-libdir.patch
+-
+-Upstream-Status: Pending
+-
+-Signed-off-by: Elliott Sales de Andrade <quantum.analyst@gmail.com>
+-Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>
+-Signed-off-by: Khem Raj <raj.khem@gmail.com>
+----
+- configure.py     |  7 +++++++
+- tools/install.py | 21 +++++++++------------
+- 2 files changed, 16 insertions(+), 12 deletions(-)
+-
+-diff --git a/configure.py b/configure.py
+-index e6f7e4db..6cf5c45d 100755
+---- a/configure.py
+-+++ b/configure.py
+-@@ -626,6 +626,12 @@ parser.add_option('--shared',
+-     help='compile shared library for embedding node in another project. ' +
+-          '(This mode is not officially supported for regular applications)')
+-
+-+parser.add_option('--libdir',
+-+    action='store',
+-+    dest='libdir',
+-+    default='lib',
+-+    help='a directory to install the shared library into')
+-+
+- parser.add_option('--without-v8-platform',
+-     action='store_true',
+-     dest='without_v8_platform',
+-@@ -1202,6 +1208,7 @@ def configure_node(o):
+-   o['variables']['node_no_browser_globals'] = b(options.no_browser_globals)
+-
+-   o['variables']['node_shared'] = b(options.shared)
+-+  o['variables']['libdir'] = options.libdir
+-   node_module_version = getmoduleversion.get_version()
+-
+-   if options.dest_os == 'android':
+-diff --git a/tools/install.py b/tools/install.py
+-index 729b416f..9bfc6234 100755
+---- a/tools/install.py
+-+++ b/tools/install.py
+-@@ -121,22 +121,19 @@ def subdir_files(path, dest, action):
+-
+- def files(action):
+-   is_windows = sys.platform == 'win32'
+--  output_file = 'node'
+-   output_prefix = 'out/Release/'
+-+  output_libprefix = output_prefix
+-
+--  if 'false' == variables.get('node_shared'):
+--    if is_windows:
+--      output_file += '.exe'
+-+  if is_windows:
+-+    output_bin = 'node.exe'
+-+    output_lib = 'node.dll'
+-   else:
+--    if is_windows:
+--      output_file += '.dll'
+--    else:
+--      output_file = 'lib' + output_file + '.' + variables.get('shlib_suffix')
+-+    output_bin = 'node'
+-+    output_lib = 'libnode.' + variables.get('shlib_suffix')
+-
+--  if 'false' == variables.get('node_shared'):
+--    action([output_prefix + output_file], 'bin/' + output_file)
+--  else:
+--    action([output_prefix + output_file], 'lib/' + output_file)
+-+  action([output_prefix + output_bin], 'bin/' + output_bin)
+-+  if 'true' == variables.get('node_shared'):
+-+    action([output_libprefix + output_lib], variables.get('libdir') + '/' + output_lib)
+-
+-   if 'true' == variables.get('node_use_dtrace'):
+-     action(['out/Release/node.d'], 'lib/dtrace/node.d')
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0003-Install-both-binaries-and-use-libdir.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0003-Install-both-binaries-and-use-libdir.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0003-Install-both-binaries-and-use-libdir.patch	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/0003-Install-both-binaries-and-use-libdir.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,87 +0,0 @@
+-From 5bfeffdf4b5de1c60a2ff0d1ddf65db2bb9a1533 Mon Sep 17 00:00:00 2001
+-From: Elliott Sales de Andrade <quantum.analyst@gmail.com>
+-Date: Tue, 19 Mar 2019 23:22:40 -0400
+-Subject: [PATCH 3/3] Install both binaries and use libdir.
+-
+-This allows us to build with a shared library for other users while
+-still providing the normal executable.
+-
+-Signed-off-by: Elliott Sales de Andrade <quantum.analyst@gmail.com>
+-
+-Stolen from [1]
+-
+-[1] https://src.fedoraproject.org/rpms/nodejs/raw/master/f/0003-Install-both-binaries-and-use-libdir.patch
+-
+-Upstream-Status: Pending
+-
+-Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>
+----
+- configure.py     |  7 +++++++
+- tools/install.py | 31 ++++++++++++++-----------------
+- 2 files changed, 21 insertions(+), 17 deletions(-)
+-
+---- a/configure.py
+-+++ b/configure.py
+-@@ -602,6 +602,12 @@ parser.add_option('--shared',
+-     help='compile shared library for embedding node in another project. ' +
+-          '(This mode is not officially supported for regular applications)')
+- 
+-+parser.add_option('--libdir',
+-+    action='store',
+-+    dest='libdir',
+-+    default='lib',
+-+    help='a directory to install the shared library into')
+-+
+- parser.add_option('--without-v8-platform',
+-     action='store_true',
+-     dest='without_v8_platform',
+-@@ -1168,6 +1174,7 @@ def configure_node(o):
+-   o['variables']['node_no_browser_globals'] = b(options.no_browser_globals)
+- 
+-   o['variables']['node_shared'] = b(options.shared)
+-+  o['variables']['libdir'] = options.libdir
+-   node_module_version = getmoduleversion.get_version()
+- 
+-   if options.dest_os == 'android':
+---- a/tools/install.py
+-+++ b/tools/install.py
+-@@ -121,26 +121,23 @@ def subdir_files(path, dest, action):
+- 
+- def files(action):
+-   is_windows = sys.platform == 'win32'
+--  output_file = 'node'
+-   output_prefix = 'out/Release/'
+-+  output_libprefix = output_prefix
+- 
+--  if 'false' == variables.get('node_shared'):
+--    if is_windows:
+--      output_file += '.exe'
+-+  if is_windows:
+-+    output_bin = 'node.exe'
+-+    output_lib = 'node.dll'
+-   else:
+--    if is_windows:
+--      output_file += '.dll'
+--    else:
+--      output_file = 'lib' + output_file + '.' + variables.get('shlib_suffix')
+--      # GYP will output to lib.target except on OS X, this is hardcoded
+--      # in its source - see the _InstallableTargetInstallPath function.
+--      if sys.platform != 'darwin':
+--        output_prefix += 'lib.target/'
+-+    output_bin = 'node'
+-+    output_lib = 'libnode.' + variables.get('shlib_suffix')
+-+    # GYP will output to lib.target except on OS X, this is hardcoded
+-+    # in its source - see the _InstallableTargetInstallPath function.
+-+    if sys.platform != 'darwin':
+-+      output_libprefix += 'lib.target/'
+- 
+--  if 'false' == variables.get('node_shared'):
+--    action([output_prefix + output_file], 'bin/' + output_file)
+--  else:
+--    action([output_prefix + output_file], 'lib/' + output_file)
+-+  action([output_prefix + output_bin], 'bin/' + output_bin)
+-+  if 'true' == variables.get('node_shared'):
+-+    action([output_libprefix + output_lib], variables.get('libdir') + '/' + output_lib)
+- 
+-   if 'true' == variables.get('node_use_dtrace'):
+-     action(['out/Release/node.d'], 'lib/dtrace/node.d')
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/CVE-2022-32212.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/CVE-2022-32212.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/CVE-2022-32212.patch	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/CVE-2022-32212.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,133 +0,0 @@
+-commit 48c5aa5cab718d04473fa2761d532657c84b8131
+-Author: Tobias Nießen <tniessen@tnie.de>
+-Date:   Fri May 27 21:18:49 2022 +0000
+-
+-    src: fix IPv4 validation in inspector_socket
+-
+-    Co-authored-by: RafaelGSS <rafael.nunu@hotmail.com>
+-    PR-URL: https://github.com/nodejs-private/node-private/pull/320
+-    Backport-PR-URL: https://github.com/nodejs-private/node-private/pull/325
+-    Reviewed-By: Matteo Collina <matteo.collina@gmail.com>
+-    Reviewed-By: RafaelGSS <rafael.nunu@hotmail.com>
+-    CVE-ID: CVE-2022-32212
+-
+-CVE: CVE-2022-32212
+-Upstream-Status: Backport [https://sources.debian.org/src/nodejs/12.22.12~dfsg-1~deb11u3/debian/patches/cve-2022-32212.patch]
+-Comment: No hunks refreshed
+-Signed-off-by: Poonam Jadhav <Poonam.Jadhav@kpit.com>
+-
+-Index: nodejs-12.22.12~dfsg/src/inspector_socket.cc
+-===================================================================
+---- nodejs-12.22.12~dfsg.orig/src/inspector_socket.cc
+-+++ nodejs-12.22.12~dfsg/src/inspector_socket.cc
+-@@ -168,14 +168,22 @@ static std::string TrimPort(const std::s
+- static bool IsIPAddress(const std::string& host) {
+-   if (host.length() >= 4 && host.front() == '[' && host.back() == ']')
+-     return true;
+--  int quads = 0;
+-+  uint_fast16_t accum = 0;
+-+  uint_fast8_t quads = 0;
+-+  bool empty = true;
+-+  auto endOctet = [&accum, &quads, &empty](bool final = false) {
+-+    return !empty && accum <= 0xff && ++quads <= 4 && final == (quads == 4) &&
+-+           (empty = true) && !(accum = 0);
+-+  };
+-   for (char c : host) {
+--    if (c == '.')
+--      quads++;
+--    else if (!isdigit(c))
+-+    if (isdigit(c)) {
+-+      if ((accum = (accum * 10) + (c - '0')) > 0xff) return false;
+-+      empty = false;
+-+    } else if (c != '.' || !endOctet()) {
+-       return false;
+-+    }
+-   }
+--  return quads == 3;
+-+  return endOctet(true);
+- }
+- 
+- // Constants for hybi-10 frame format.
+-Index: nodejs-12.22.12~dfsg/test/cctest/test_inspector_socket.cc
+-===================================================================
+---- nodejs-12.22.12~dfsg.orig/test/cctest/test_inspector_socket.cc
+-+++ nodejs-12.22.12~dfsg/test/cctest/test_inspector_socket.cc
+-@@ -851,4 +851,78 @@ TEST_F(InspectorSocketTest, HostCheckedF
+-   expect_failure_no_delegate(UPGRADE_REQUEST);
+- }
+- 
+-+TEST_F(InspectorSocketTest, HostIPChecked) {
+-+  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+-+                                              "Host: 10.0.2.555:9229\r\n\r\n";
+-+  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+-+                 INVALID_HOST_IP_REQUEST.length());
+-+  expect_handshake_failure();
+-+}
+-+
+-+TEST_F(InspectorSocketTest, HostNegativeIPChecked) {
+-+  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+-+                                              "Host: 10.0.-23.255:9229\r\n\r\n";
+-+  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+-+                 INVALID_HOST_IP_REQUEST.length());
+-+  expect_handshake_failure();
+-+}
+-+
+-+TEST_F(InspectorSocketTest, HostIpOctetOutOfIntRangeChecked) {
+-+  const std::string INVALID_HOST_IP_REQUEST =
+-+      "GET /json HTTP/1.1\r\n"
+-+      "Host: 127.0.0.4294967296:9229\r\n\r\n";
+-+  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+-+                 INVALID_HOST_IP_REQUEST.length());
+-+  expect_handshake_failure();
+-+}
+-+
+-+TEST_F(InspectorSocketTest, HostIpOctetFarOutOfIntRangeChecked) {
+-+  const std::string INVALID_HOST_IP_REQUEST =
+-+      "GET /json HTTP/1.1\r\n"
+-+      "Host: 127.0.0.18446744073709552000:9229\r\n\r\n";
+-+  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+-+                 INVALID_HOST_IP_REQUEST.length());
+-+  expect_handshake_failure();
+-+}
+-+
+-+TEST_F(InspectorSocketTest, HostIpEmptyOctetStartChecked) {
+-+  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+-+                                              "Host: .0.0.1:9229\r\n\r\n";
+-+  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+-+                 INVALID_HOST_IP_REQUEST.length());
+-+  expect_handshake_failure();
+-+}
+-+
+-+TEST_F(InspectorSocketTest, HostIpEmptyOctetMidChecked) {
+-+  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+-+                                              "Host: 127..0.1:9229\r\n\r\n";
+-+  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+-+                 INVALID_HOST_IP_REQUEST.length());
+-+  expect_handshake_failure();
+-+}
+-+
+-+TEST_F(InspectorSocketTest, HostIpEmptyOctetEndChecked) {
+-+  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+-+                                              "Host: 127.0.0.:9229\r\n\r\n";
+-+  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+-+                 INVALID_HOST_IP_REQUEST.length());
+-+  expect_handshake_failure();
+-+}
+-+
+-+TEST_F(InspectorSocketTest, HostIpTooFewOctetsChecked) {
+-+  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+-+                                              "Host: 127.0.1:9229\r\n\r\n";
+-+  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+-+                 INVALID_HOST_IP_REQUEST.length());
+-+  expect_handshake_failure();
+-+}
+-+
+-+TEST_F(InspectorSocketTest, HostIpTooManyOctetsChecked) {
+-+  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+-+                                              "Host: 127.0.0.0.1:9229\r\n\r\n";
+-+  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+-+                 INVALID_HOST_IP_REQUEST.length());
+-+  expect_handshake_failure();
+-+}
+-+
+- }  // anonymous namespace
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/CVE-2022-35255.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/CVE-2022-35255.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/CVE-2022-35255.patch	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/CVE-2022-35255.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,237 +0,0 @@
+-Origin: https://github.com/nodejs/node/commit/0c2a5723beff39d1f62daec96b5389da3d427e79
+-Reviewed-by: Aron Xu <aron@debian.org>
+-Last-Update: 2022-01-05
+-Comment:
+-  Although WebCrypto is not implemented in 12.x series, this fix is introducing
+-  enhancment to the crypto setup of V8:EntropySource().
+-
+-commit 0c2a5723beff39d1f62daec96b5389da3d427e79
+-Author: Ben Noordhuis <info@bnoordhuis.nl>
+-Date:   Sun Sep 11 10:48:34 2022 +0200
+-
+-    crypto: fix weak randomness in WebCrypto keygen
+-    
+-    Commit dae283d96f from August 2020 introduced a call to EntropySource()
+-    in SecretKeyGenTraits::DoKeyGen() in src/crypto/crypto_keygen.cc. There
+-    are two problems with that:
+-    
+-    1. It does not check the return value, it assumes EntropySource() always
+-       succeeds, but it can (and sometimes will) fail.
+-    
+-    2. The random data returned byEntropySource() may not be
+-       cryptographically strong and therefore not suitable as keying
+-       material.
+-    
+-    An example is a freshly booted system or a system without /dev/random or
+-    getrandom(2).
+-    
+-    EntropySource() calls out to openssl's RAND_poll() and RAND_bytes() in a
+-    best-effort attempt to obtain random data. OpenSSL has a built-in CSPRNG
+-    but that can fail to initialize, in which case it's possible either:
+-    
+-    1. No random data gets written to the output buffer, i.e., the output is
+-       unmodified, or
+-    
+-    2. Weak random data is written. It's theoretically possible for the
+-       output to be fully predictable because the CSPRNG starts from a
+-       predictable state.
+-    
+-    Replace EntropySource() and CheckEntropy() with new function CSPRNG()
+-    that enforces checking of the return value. Abort on startup when the
+-    entropy pool fails to initialize because that makes it too easy to
+-    compromise the security of the process.
+-    
+-    Refs: https://hackerone.com/bugs?report_id=1690000
+-    Refs: https://github.com/nodejs/node/pull/35093
+-    
+-    Reviewed-By: Rafael Gonzaga <rafael.nunu@hotmail.com>
+-    Reviewed-By: Tobias Nießen <tniessen@tnie.de>
+-    PR-URL: #346
+-    Backport-PR-URL: #351
+-    CVE-ID: CVE-2022-35255
+-
+-CVE: CVE-2022-35255
+-Upstream-Status: Backport [https://sources.debian.org/src/nodejs/12.22.12~dfsg-1~deb11u3/debian/patches/cve-2022-35255.patch]
+-Comment: No hunks refreshed
+-Signed-off-by: Poonam Jadhav <Poonam.Jadhav@kpit.com>
+-
+-Index: nodejs-12.22.12~dfsg/node.gyp
+-===================================================================
+---- nodejs-12.22.12~dfsg.orig/node.gyp
+-+++ nodejs-12.22.12~dfsg/node.gyp
+-@@ -743,6 +743,8 @@
+-         'openssl_default_cipher_list%': '',
+-       },
+- 
+-+      'cflags': ['-Werror=unused-result'],
+-+
+-       'defines': [
+-         'NODE_ARCH="<(target_arch)"',
+-         'NODE_PLATFORM="<(OS)"',
+-Index: nodejs-12.22.12~dfsg/src/node_crypto.cc
+-===================================================================
+---- nodejs-12.22.12~dfsg.orig/src/node_crypto.cc
+-+++ nodejs-12.22.12~dfsg/src/node_crypto.cc
+-@@ -386,48 +386,14 @@ void ThrowCryptoError(Environment* env,
+-   env->isolate()->ThrowException(exception);
+- }
+- 
+-+MUST_USE_RESULT CSPRNGResult CSPRNG(void* buffer, size_t length) {
+-+  do {
+-+    if (1 == RAND_status())
+-+      if (1 == RAND_bytes(static_cast<unsigned char*>(buffer), length))
+-+        return {true};
+-+  } while (1 == RAND_poll());
+- 
+--// Ensure that OpenSSL has enough entropy (at least 256 bits) for its PRNG.
+--// The entropy pool starts out empty and needs to fill up before the PRNG
+--// can be used securely.  Once the pool is filled, it never dries up again;
+--// its contents is stirred and reused when necessary.
+--//
+--// OpenSSL normally fills the pool automatically but not when someone starts
+--// generating random numbers before the pool is full: in that case OpenSSL
+--// keeps lowering the entropy estimate to thwart attackers trying to guess
+--// the initial state of the PRNG.
+--//
+--// When that happens, we will have to wait until enough entropy is available.
+--// That should normally never take longer than a few milliseconds.
+--//
+--// OpenSSL draws from /dev/random and /dev/urandom.  While /dev/random may
+--// block pending "true" randomness, /dev/urandom is a CSPRNG that doesn't
+--// block under normal circumstances.
+--//
+--// The only time when /dev/urandom may conceivably block is right after boot,
+--// when the whole system is still low on entropy.  That's not something we can
+--// do anything about.
+--inline void CheckEntropy() {
+--  for (;;) {
+--    int status = RAND_status();
+--    CHECK_GE(status, 0);  // Cannot fail.
+--    if (status != 0)
+--      break;
+--
+--    // Give up, RAND_poll() not supported.
+--    if (RAND_poll() == 0)
+--      break;
+--  }
+--}
+--
+--
+--bool EntropySource(unsigned char* buffer, size_t length) {
+--  // Ensure that OpenSSL's PRNG is properly seeded.
+--  CheckEntropy();
+--  // RAND_bytes() can return 0 to indicate that the entropy data is not truly
+--  // random. That's okay, it's still better than V8's stock source of entropy,
+--  // which is /dev/urandom on UNIX platforms and the current time on Windows.
+--  return RAND_bytes(buffer, length) != -1;
+-+  return {false};
+- }
+- 
+- void SecureContext::Initialize(Environment* env, Local<Object> target) {
+-@@ -649,9 +615,9 @@ void SecureContext::Init(const FunctionC
+-   // OpenSSL 1.1.0 changed the ticket key size, but the OpenSSL 1.0.x size was
+-   // exposed in the public API. To retain compatibility, install a callback
+-   // which restores the old algorithm.
+--  if (RAND_bytes(sc->ticket_key_name_, sizeof(sc->ticket_key_name_)) <= 0 ||
+--      RAND_bytes(sc->ticket_key_hmac_, sizeof(sc->ticket_key_hmac_)) <= 0 ||
+--      RAND_bytes(sc->ticket_key_aes_, sizeof(sc->ticket_key_aes_)) <= 0) {
+-+  if (CSPRNG(sc->ticket_key_name_, sizeof(sc->ticket_key_name_)).is_err() ||
+-+      CSPRNG(sc->ticket_key_hmac_, sizeof(sc->ticket_key_hmac_)).is_err() ||
+-+      CSPRNG(sc->ticket_key_aes_, sizeof(sc->ticket_key_aes_)).is_err()) {
+-     return env->ThrowError("Error generating ticket keys");
+-   }
+-   SSL_CTX_set_tlsext_ticket_key_cb(sc->ctx_.get(), TicketCompatibilityCallback);
+-@@ -1643,7 +1609,7 @@ int SecureContext::TicketCompatibilityCa
+- 
+-   if (enc) {
+-     memcpy(name, sc->ticket_key_name_, sizeof(sc->ticket_key_name_));
+--    if (RAND_bytes(iv, 16) <= 0 ||
+-+    if (CSPRNG(iv, 16).is_err() ||
+-         EVP_EncryptInit_ex(ectx, EVP_aes_128_cbc(), nullptr,
+-                            sc->ticket_key_aes_, iv) <= 0 ||
+-         HMAC_Init_ex(hctx, sc->ticket_key_hmac_, sizeof(sc->ticket_key_hmac_),
+-@@ -5867,8 +5833,7 @@ struct RandomBytesJob : public CryptoJob
+-       : CryptoJob(env), rc(Nothing<int>()) {}
+- 
+-   inline void DoThreadPoolWork() override {
+--    CheckEntropy();  // Ensure that OpenSSL's PRNG is properly seeded.
+--    rc = Just(RAND_bytes(data, size));
+-+    rc = Just(int(CSPRNG(data, size).is_ok()));
+-     if (0 == rc.FromJust()) errors.Capture();
+-   }
+- 
+-@@ -6318,8 +6283,8 @@ class GenerateKeyPairJob : public Crypto
+-   }
+- 
+-   inline bool GenerateKey() {
+--    // Make sure that the CSPRNG is properly seeded so the results are secure.
+--    CheckEntropy();
+-+    // Make sure that the CSPRNG is properly seeded.
+-+    CHECK(CSPRNG(nullptr, 0).is_ok());
+- 
+-     // Create the key generation context.
+-     EVPKeyCtxPointer ctx = config_->Setup();
+-Index: nodejs-12.22.12~dfsg/src/node_crypto.h
+-===================================================================
+---- nodejs-12.22.12~dfsg.orig/src/node_crypto.h
+-+++ nodejs-12.22.12~dfsg/src/node_crypto.h
+-@@ -840,7 +840,19 @@ class ECDH final : public BaseObject {
+-   const EC_GROUP* group_;
+- };
+- 
+--bool EntropySource(unsigned char* buffer, size_t length);
+-+struct CSPRNGResult {
+-+  const bool ok;
+-+  MUST_USE_RESULT bool is_ok() const { return ok; }
+-+  MUST_USE_RESULT bool is_err() const { return !ok; }
+-+};
+-+
+-+// Either succeeds with exactly |length| bytes of cryptographically
+-+// strong pseudo-random data, or fails. This function may block.
+-+// Don't assume anything about the contents of |buffer| on error.
+-+// As a special case, |length == 0| can be used to check if the CSPRNG
+-+// is properly seeded without consuming entropy.
+-+MUST_USE_RESULT CSPRNGResult CSPRNG(void* buffer, size_t length);
+-+
+- #ifndef OPENSSL_NO_ENGINE
+- void SetEngine(const v8::FunctionCallbackInfo<v8::Value>& args);
+- #endif  // !OPENSSL_NO_ENGINE
+-Index: nodejs-12.22.12~dfsg/src/inspector_io.cc
+-===================================================================
+---- nodejs-12.22.12~dfsg.orig/src/inspector_io.cc
+-+++ nodejs-12.22.12~dfsg/src/inspector_io.cc
+-@@ -46,8 +46,7 @@ std::string ScriptPath(uv_loop_t* loop,
+- // Used ver 4 - with numbers
+- std::string GenerateID() {
+-   uint16_t buffer[8];
+--  CHECK(crypto::EntropySource(reinterpret_cast<unsigned char*>(buffer),
+--                              sizeof(buffer)));
+-+  CHECK(crypto::CSPRNG(buffer, sizeof(buffer)).is_ok());
+- 
+-   char uuid[256];
+-   snprintf(uuid, sizeof(uuid), "%04x%04x-%04x-%04x-%04x-%04x%04x%04x",
+-Index: nodejs-12.22.12~dfsg/src/node.cc
+-===================================================================
+---- nodejs-12.22.12~dfsg.orig/src/node.cc
+-+++ nodejs-12.22.12~dfsg/src/node.cc
+-@@ -969,9 +969,17 @@ InitializationResult InitializeOncePerPr
+-   // the random source is properly initialized first.
+-   OPENSSL_init();
+- #endif  // NODE_FIPS_MODE
+--  // V8 on Windows doesn't have a good source of entropy. Seed it from
+--  // OpenSSL's pool.
+--  V8::SetEntropySource(crypto::EntropySource);
+-+  // Ensure CSPRNG is properly seeded.
+-+  CHECK(crypto::CSPRNG(nullptr, 0).is_ok());
+-+
+-+  V8::SetEntropySource([](unsigned char* buffer, size_t length) {
+-+    // V8 falls back to very weak entropy when this function fails
+-+    // and /dev/urandom isn't available. That wouldn't be so bad if
+-+    // the entropy was only used for Math.random() but it's also used for
+-+    // hash table and address space layout randomization. Better to abort.
+-+    CHECK(crypto::CSPRNG(buffer, length).is_ok());
+-+    return true;
+-+    });
+- #endif  // HAVE_OPENSSL
+- 
+-   per_process::v8_platform.Initialize(
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/CVE-2022-43548.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/CVE-2022-43548.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/CVE-2022-43548.patch	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/CVE-2022-43548.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,214 +0,0 @@
+-commit 2b433af094fb79cf80f086038b7f36342cb6826f
+-Author: Tobias Nießen <tniessen@tnie.de>
+-Date:   Sun Sep 25 12:34:05 2022 +0000
+-
+-    inspector: harden IP address validation again
+-    
+-    Use inet_pton() to parse IP addresses, which restricts IP addresses
+-    to a small number of well-defined formats. In particular, octal and
+-    hexadecimal number formats are not allowed, and neither are leading
+-    zeros. Also explicitly reject 0.0.0.0/8 and ::/128 as non-routable.
+-    
+-    Refs: https://hackerone.com/reports/1710652
+-    CVE-ID: CVE-2022-43548
+-    PR-URL: https://github.com/nodejs-private/node-private/pull/354
+-    Reviewed-by: Michael Dawson <midawson@redhat.com>
+-    Reviewed-by: Rafael Gonzaga <rafael.nunu@hotmail.com>
+-    Reviewed-by: Rich Trott <rtrott@gmail.com>
+-
+-CVE: CVE-2022-43548
+-Upstream-Status: Backport [https://sources.debian.org/src/nodejs/12.22.12~dfsg-1~deb11u3/debian/patches/cve-2022-43548.patch]
+-Comment: No hunks refreshed
+-Signed-off-by: Poonam Jadhav <Poonam.Jadhav@kpit.com>
+-
+-Index: nodejs-12.22.12~dfsg/src/inspector_socket.cc
+-===================================================================
+---- nodejs-12.22.12~dfsg.orig/src/inspector_socket.cc
+-+++ nodejs-12.22.12~dfsg/src/inspector_socket.cc
+-@@ -10,6 +10,7 @@
+- 
+- #include "openssl/sha.h"  // Sha-1 hash
+- 
+-+#include <algorithm>
+- #include <cstring>
+- #include <map>
+- 
+-@@ -166,25 +167,71 @@ static std::string TrimPort(const std::s
+- }
+- 
+- static bool IsIPAddress(const std::string& host) {
+--  if (host.length() >= 4 && host.front() == '[' && host.back() == ']')
+-+  // TODO(tniessen): add CVEs to the following bullet points
+-+  // To avoid DNS rebinding attacks, we are aware of the following requirements:
+-+  // * the host name must be an IP address,
+-+  // * the IP address must be routable, and
+-+  // * the IP address must be formatted unambiguously.
+-+
+-+  // The logic below assumes that the string is null-terminated, so ensure that
+-+  // we did not somehow end up with null characters within the string.
+-+  if (host.find('\0') != std::string::npos) return false;
+-+
+-+  // All IPv6 addresses must be enclosed in square brackets, and anything
+-+  // enclosed in square brackets must be an IPv6 address.
+-+  if (host.length() >= 4 && host.front() == '[' && host.back() == ']') {
+-+    // INET6_ADDRSTRLEN is the maximum length of the dual format (including the
+-+    // terminating null character), which is the longest possible representation
+-+    // of an IPv6 address: xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:ddd.ddd.ddd.ddd
+-+    if (host.length() - 2 >= INET6_ADDRSTRLEN) return false;
+-+
+-+    // Annoyingly, libuv's implementation of inet_pton() deviates from other
+-+    // implementations of the function in that it allows '%' in IPv6 addresses.
+-+    if (host.find('%') != std::string::npos) return false;
+-+
+-+    // Parse the IPv6 address to ensure it is syntactically valid.
+-+    char ipv6_str[INET6_ADDRSTRLEN];
+-+    std::copy(host.begin() + 1, host.end() - 1, ipv6_str);
+-+    ipv6_str[host.length()] = '\0';
+-+    unsigned char ipv6[sizeof(struct in6_addr)];
+-+    if (uv_inet_pton(AF_INET6, ipv6_str, ipv6) != 0) return false;
+-+
+-+    // The only non-routable IPv6 address is ::/128. It should not be necessary
+-+    // to explicitly reject it because it will still be enclosed in square
+-+    // brackets and not even macOS should make DNS requests in that case, but
+-+    // history has taught us that we cannot be careful enough.
+-+    // Note that RFC 4291 defines both "IPv4-Compatible IPv6 Addresses" and
+-+    // "IPv4-Mapped IPv6 Addresses", which means that there are IPv6 addresses
+-+    // (other than ::/128) that represent non-routable IPv4 addresses. However,
+-+    // this translation assumes that the host is interpreted as an IPv6 address
+-+    // in the first place, at which point DNS rebinding should not be an issue.
+-+    if (std::all_of(ipv6, ipv6 + sizeof(ipv6), [](auto b) { return b == 0; })) {
+-+       return false;
+-+     }
+-+
+-+    // It is a syntactically valid and routable IPv6 address enclosed in square
+-+    // brackets. No client should be able to misinterpret this.
+-     return true;
+--  uint_fast16_t accum = 0;
+--  uint_fast8_t quads = 0;
+--  bool empty = true;
+--  auto endOctet = [&accum, &quads, &empty](bool final = false) {
+--    return !empty && accum <= 0xff && ++quads <= 4 && final == (quads == 4) &&
+--           (empty = true) && !(accum = 0);
+--  };
+--  for (char c : host) {
+--    if (isdigit(c)) {
+--      if ((accum = (accum * 10) + (c - '0')) > 0xff) return false;
+--      empty = false;
+--    } else if (c != '.' || !endOctet()) {
+--      return false;
+--    }
+--  }
+--  return endOctet(true);
+--}
+-+   }
+-+
+-+  // Anything not enclosed in square brackets must be an IPv4 address. It is
+-+  // important here that inet_pton() accepts only the so-called dotted-decimal
+-+  // notation, which is a strict subset of the so-called numbers-and-dots
+-+  // notation that is allowed by inet_aton() and inet_addr(). This subset does
+-+  // not allow hexadecimal or octal number formats.
+-+  unsigned char ipv4[sizeof(struct in_addr)];
+-+  if (uv_inet_pton(AF_INET, host.c_str(), ipv4) != 0) return false;
+-+
+-+  // The only strictly non-routable IPv4 address is 0.0.0.0, and macOS will make
+-+  // DNS requests for this IP address, so we need to explicitly reject it. In
+-+  // fact, we can safely reject all of 0.0.0.0/8 (see Section 3.2 of RFC 791 and
+-+  // Section 3.2.1.3 of RFC 1122).
+-+  // Note that inet_pton() stores the IPv4 address in network byte order.
+-+  if (ipv4[0] == 0) return false;
+-+
+-+  // It is a routable IPv4 address in dotted-decimal notation.
+-+  return true;
+-+ }
+- 
+- // Constants for hybi-10 frame format.
+- 
+-Index: nodejs-12.22.12~dfsg/test/cctest/test_inspector_socket.cc
+-===================================================================
+---- nodejs-12.22.12~dfsg.orig/test/cctest/test_inspector_socket.cc
+-+++ nodejs-12.22.12~dfsg/test/cctest/test_inspector_socket.cc
+-@@ -925,4 +925,84 @@ TEST_F(InspectorSocketTest, HostIpTooMan
+-   expect_handshake_failure();
+- }
+- 
+-+TEST_F(InspectorSocketTest, HostIpInvalidOctalOctetStartChecked) {
+-+  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+-+                                              "Host: 08.1.1.1:9229\r\n\r\n";
+-+  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+-+                 INVALID_HOST_IP_REQUEST.length());
+-+  expect_handshake_failure();
+-+}
+-+
+-+TEST_F(InspectorSocketTest, HostIpInvalidOctalOctetMidChecked) {
+-+  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+-+                                              "Host: 1.09.1.1:9229\r\n\r\n";
+-+  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+-+                 INVALID_HOST_IP_REQUEST.length());
+-+  expect_handshake_failure();
+-+}
+-+
+-+TEST_F(InspectorSocketTest, HostIpInvalidOctalOctetEndChecked) {
+-+  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+-+                                              "Host: 1.1.1.009:9229\r\n\r\n";
+-+  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+-+                 INVALID_HOST_IP_REQUEST.length());
+-+  expect_handshake_failure();
+-+}
+-+
+-+TEST_F(InspectorSocketTest, HostIpLeadingZeroStartChecked) {
+-+  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+-+                                              "Host: 01.1.1.1:9229\r\n\r\n";
+-+  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+-+                 INVALID_HOST_IP_REQUEST.length());
+-+  expect_handshake_failure();
+-+}
+-+
+-+TEST_F(InspectorSocketTest, HostIpLeadingZeroMidChecked) {
+-+  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+-+                                              "Host: 1.1.001.1:9229\r\n\r\n";
+-+  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+-+                 INVALID_HOST_IP_REQUEST.length());
+-+  expect_handshake_failure();
+-+}
+-+
+-+TEST_F(InspectorSocketTest, HostIpLeadingZeroEndChecked) {
+-+  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+-+                                              "Host: 1.1.1.01:9229\r\n\r\n";
+-+  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+-+                 INVALID_HOST_IP_REQUEST.length());
+-+  expect_handshake_failure();
+-+}
+-+
+-+TEST_F(InspectorSocketTest, HostIPv6NonRoutable) {
+-+  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+-+                                              "Host: [::]:9229\r\n\r\n";
+-+  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+-+                 INVALID_HOST_IP_REQUEST.length());
+-+  expect_handshake_failure();
+-+}
+-+
+-+TEST_F(InspectorSocketTest, HostIPv6NonRoutableDual) {
+-+  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+-+                                              "Host: [::0.0.0.0]:9229\r\n\r\n";
+-+  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+-+                 INVALID_HOST_IP_REQUEST.length());
+-+  expect_handshake_failure();
+-+}
+-+
+-+TEST_F(InspectorSocketTest, HostIPv4InSquareBrackets) {
+-+  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+-+                                              "Host: [127.0.0.1]:9229\r\n\r\n";
+-+  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+-+                 INVALID_HOST_IP_REQUEST.length());
+-+  expect_handshake_failure();
+-+}
+-+
+-+TEST_F(InspectorSocketTest, HostIPv6InvalidAbbreviation) {
+-+  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+-+                                              "Host: [:::1]:9229\r\n\r\n";
+-+  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+-+                 INVALID_HOST_IP_REQUEST.length());
+-+  expect_handshake_failure();
+-+}
+-+
+- }  // anonymous namespace
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/CVE-llhttp.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/CVE-llhttp.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/CVE-llhttp.patch	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/CVE-llhttp.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,4348 +0,0 @@
+-Reviewed-by: Aron Xu <aron@debian.org>
+-Last-Update: 2023-01-05
+-Comment:
+-  This patch updates the embeded copy of llhttp from version 2.1.4 to 2.1.6,
+-  which is upstream's actual fix for CVE-2022-32213, CVE-2022-32214, CVE-2022-32215,
+-  CVE-2022-35256.
+-  Test cases are ported to use mustCall() to replace the later introduced
+-  mustSucceed(), to avoid pulling in too many dependent new test codes.
+-References:
+-  * https://github.com/nodejs/node/commit/da0fda0fe81d372e24c0cb11aec37534985708dd
+-  * https://github.com/nodejs/node/commit/a9f1146b8827855e342834458a71f2367346ace0
+-
+-CVE: CVE-2022-32213 CVE-2022-32214 CVE-2022-32215 CVE-2022-35256
+-Upstream-Status: Backport [https://sources.debian.org/src/nodejs/12.22.12~dfsg-1~deb11u3/debian/patches/cve-llhttp.patch]
+-Comment: No hunks refreshed
+-Signed-off-by: Poonam Jadhav <Poonam.Jadhav@kpit.com>
+-
+---- nodejs-12.22.12~dfsg/deps/llhttp/include/llhttp.h
+-+++ nodejs-12.22.12~dfsg/deps/llhttp/include/llhttp.h
+-@@ -3,7 +3,7 @@
+- 
+- #define LLHTTP_VERSION_MAJOR 2
+- #define LLHTTP_VERSION_MINOR 1
+--#define LLHTTP_VERSION_PATCH 4
+-+#define LLHTTP_VERSION_PATCH 6
+- 
+- #ifndef LLHTTP_STRICT_MODE
+- # define LLHTTP_STRICT_MODE 0
+-@@ -58,6 +58,7 @@
+-   HPE_OK = 0,
+-   HPE_INTERNAL = 1,
+-   HPE_STRICT = 2,
+-+  HPE_CR_EXPECTED = 25,
+-   HPE_LF_EXPECTED = 3,
+-   HPE_UNEXPECTED_CONTENT_LENGTH = 4,
+-   HPE_CLOSED_CONNECTION = 5,
+-@@ -78,7 +79,7 @@
+-   HPE_CB_CHUNK_COMPLETE = 20,
+-   HPE_PAUSED = 21,
+-   HPE_PAUSED_UPGRADE = 22,
+--  HPE_USER = 23
+-+  HPE_USER = 24
+- };
+- typedef enum llhttp_errno llhttp_errno_t;
+- 
+-@@ -153,6 +154,7 @@
+-   XX(0, OK, OK) \
+-   XX(1, INTERNAL, INTERNAL) \
+-   XX(2, STRICT, STRICT) \
+-+  XX(25, CR_EXPECTED, CR_EXPECTED) \
+-   XX(3, LF_EXPECTED, LF_EXPECTED) \
+-   XX(4, UNEXPECTED_CONTENT_LENGTH, UNEXPECTED_CONTENT_LENGTH) \
+-   XX(5, CLOSED_CONNECTION, CLOSED_CONNECTION) \
+-@@ -173,7 +175,7 @@
+-   XX(20, CB_CHUNK_COMPLETE, CB_CHUNK_COMPLETE) \
+-   XX(21, PAUSED, PAUSED) \
+-   XX(22, PAUSED_UPGRADE, PAUSED_UPGRADE) \
+--  XX(23, USER, USER) \
+-+  XX(24, USER, USER) \
+- 
+- 
+- #define HTTP_METHOD_MAP(XX) \
+---- nodejs-12.22.12~dfsg/deps/llhttp/src/llhttp.c
+-+++ nodejs-12.22.12~dfsg/deps/llhttp/src/llhttp.c
+-@@ -325,6 +325,7 @@
+-   s_n_llhttp__internal__n_header_value_lws,
+-   s_n_llhttp__internal__n_header_value_almost_done,
+-   s_n_llhttp__internal__n_header_value_lenient,
+-+  s_n_llhttp__internal__n_error_25,
+-   s_n_llhttp__internal__n_header_value_otherwise,
+-   s_n_llhttp__internal__n_header_value_connection_token,
+-   s_n_llhttp__internal__n_header_value_connection_ws,
+-@@ -332,14 +333,16 @@
+-   s_n_llhttp__internal__n_header_value_connection_2,
+-   s_n_llhttp__internal__n_header_value_connection_3,
+-   s_n_llhttp__internal__n_header_value_connection,
+--  s_n_llhttp__internal__n_error_26,
+-   s_n_llhttp__internal__n_error_27,
+-+  s_n_llhttp__internal__n_error_28,
+-   s_n_llhttp__internal__n_header_value_content_length_ws,
+-   s_n_llhttp__internal__n_header_value_content_length,
+--  s_n_llhttp__internal__n_header_value_te_chunked_last,
+-+  s_n_llhttp__internal__n_error_30,
+-+  s_n_llhttp__internal__n_error_29,
+-   s_n_llhttp__internal__n_header_value_te_token_ows,
+-   s_n_llhttp__internal__n_header_value,
+-   s_n_llhttp__internal__n_header_value_te_token,
+-+  s_n_llhttp__internal__n_header_value_te_chunked_last,
+-   s_n_llhttp__internal__n_header_value_te_chunked,
+-   s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1,
+-   s_n_llhttp__internal__n_header_value_discard_ws,
+-@@ -734,7 +737,7 @@
+-   return 0;
+- }
+- 
+--int llhttp__internal__c_update_header_state_2(
+-+int llhttp__internal__c_update_header_state_3(
+-     llhttp__internal_t* state,
+-     const unsigned char* p,
+-     const unsigned char* endp) {
+-@@ -742,7 +745,7 @@
+-   return 0;
+- }
+- 
+--int llhttp__internal__c_update_header_state_4(
+-+int llhttp__internal__c_update_header_state_1(
+-     llhttp__internal_t* state,
+-     const unsigned char* p,
+-     const unsigned char* endp) {
+-@@ -750,7 +753,7 @@
+-   return 0;
+- }
+- 
+--int llhttp__internal__c_update_header_state_5(
+-+int llhttp__internal__c_update_header_state_6(
+-     llhttp__internal_t* state,
+-     const unsigned char* p,
+-     const unsigned char* endp) {
+-@@ -758,7 +761,7 @@
+-   return 0;
+- }
+- 
+--int llhttp__internal__c_update_header_state_6(
+-+int llhttp__internal__c_update_header_state_7(
+-     llhttp__internal_t* state,
+-     const unsigned char* p,
+-     const unsigned char* endp) {
+-@@ -766,7 +769,7 @@
+-   return 0;
+- }
+- 
+--int llhttp__internal__c_test_flags_6(
+-+int llhttp__internal__c_test_flags_7(
+-     llhttp__internal_t* state,
+-     const unsigned char* p,
+-     const unsigned char* endp) {
+-@@ -807,6 +810,13 @@
+-   return 0;
+- }
+- 
+-+int llhttp__internal__c_test_flags_8(
+-+    llhttp__internal_t* state,
+-+    const unsigned char* p,
+-+    const unsigned char* endp) {
+-+  return (state->flags & 8) == 8;
+-+}
+-+
+- int llhttp__internal__c_or_flags_16(
+-     llhttp__internal_t* state,
+-     const unsigned char* p,
+-@@ -823,7 +833,7 @@
+-   return 0;
+- }
+- 
+--int llhttp__internal__c_update_header_state_7(
+-+int llhttp__internal__c_update_header_state_8(
+-     llhttp__internal_t* state,
+-     const unsigned char* p,
+-     const unsigned char* endp) {
+-@@ -831,7 +841,7 @@
+-   return 0;
+- }
+- 
+--int llhttp__internal__c_or_flags_17(
+-+int llhttp__internal__c_or_flags_18(
+-     llhttp__internal_t* state,
+-     const unsigned char* p,
+-     const unsigned char* endp) {
+-@@ -1554,7 +1564,7 @@
+-           goto s_n_llhttp__internal__n_header_value_discard_lws;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_22;
+-+          goto s_n_llhttp__internal__n_error_23;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -1567,13 +1577,13 @@
+-       }
+-       switch (*p) {
+-         case 9: {
+--          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+-+          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
+-         }
+-         case ' ': {
+--          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+-+          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
+-+          goto s_n_llhttp__internal__n_invoke_load_header_state_4;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -1590,7 +1600,7 @@
+-           goto s_n_llhttp__internal__n_header_value_lws;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_23;
+-+          goto s_n_llhttp__internal__n_error_24;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -1603,10 +1613,10 @@
+-       }
+-       switch (*p) {
+-         case 10: {
+--          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
+-+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3;
+-         }
+-         case 13: {
+--          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3;
+-+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4;
+-         }
+-         default: {
+-           p++;
+-@@ -1616,20 +1626,27 @@
+-       /* UNREACHABLE */;
+-       abort();
+-     }
+-+    case s_n_llhttp__internal__n_error_25:
+-+    s_n_llhttp__internal__n_error_25: {
+-+      state->error = 0xa;
+-+      state->reason = "Invalid header value char";
+-+      state->error_pos = (const char*) p;
+-+      state->_current = (void*) (intptr_t) s_error;
+-+      return s_error;
+-+      /* UNREACHABLE */;
+-+      abort();
+-+    }
+-     case s_n_llhttp__internal__n_header_value_otherwise:
+-     s_n_llhttp__internal__n_header_value_otherwise: {
+-       if (p == endp) {
+-         return s_n_llhttp__internal__n_header_value_otherwise;
+-       }
+-       switch (*p) {
+--        case 10: {
+--          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
+--        }
+-         case 13: {
+--          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2;
+-+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_invoke_test_flags_5;
+-+          goto s_n_llhttp__internal__n_invoke_test_flags_6;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -1692,10 +1709,10 @@
+-         }
+-         case ',': {
+-           p++;
+--          goto s_n_llhttp__internal__n_invoke_load_header_state_4;
+-+          goto s_n_llhttp__internal__n_invoke_load_header_state_5;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_4;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_5;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -1713,7 +1730,7 @@
+-       switch (match_seq.status) {
+-         case kMatchComplete: {
+-           p++;
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_2;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+-         }
+-         case kMatchPause: {
+-           return s_n_llhttp__internal__n_header_value_connection_1;
+-@@ -1737,7 +1754,7 @@
+-       switch (match_seq.status) {
+-         case kMatchComplete: {
+-           p++;
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_5;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_6;
+-         }
+-         case kMatchPause: {
+-           return s_n_llhttp__internal__n_header_value_connection_2;
+-@@ -1761,7 +1778,7 @@
+-       switch (match_seq.status) {
+-         case kMatchComplete: {
+-           p++;
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_6;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
+-         }
+-         case kMatchPause: {
+-           return s_n_llhttp__internal__n_header_value_connection_3;
+-@@ -1806,8 +1823,8 @@
+-       /* UNREACHABLE */;
+-       abort();
+-     }
+--    case s_n_llhttp__internal__n_error_26:
+--    s_n_llhttp__internal__n_error_26: {
+-+    case s_n_llhttp__internal__n_error_27:
+-+    s_n_llhttp__internal__n_error_27: {
+-       state->error = 0xb;
+-       state->reason = "Content-Length overflow";
+-       state->error_pos = (const char*) p;
+-@@ -1816,8 +1833,8 @@
+-       /* UNREACHABLE */;
+-       abort();
+-     }
+--    case s_n_llhttp__internal__n_error_27:
+--    s_n_llhttp__internal__n_error_27: {
+-+    case s_n_llhttp__internal__n_error_28:
+-+    s_n_llhttp__internal__n_error_28: {
+-       state->error = 0xb;
+-       state->reason = "Invalid character in Content-Length";
+-       state->error_pos = (const char*) p;
+-@@ -1843,7 +1860,7 @@
+-           goto s_n_llhttp__internal__n_header_value_content_length_ws;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5;
+-+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_6;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -1912,26 +1929,23 @@
+-       /* UNREACHABLE */;
+-       abort();
+-     }
+--    case s_n_llhttp__internal__n_header_value_te_chunked_last:
+--    s_n_llhttp__internal__n_header_value_te_chunked_last: {
+--      if (p == endp) {
+--        return s_n_llhttp__internal__n_header_value_te_chunked_last;
+--      }
+--      switch (*p) {
+--        case 10: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
+--        }
+--        case 13: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
+--        }
+--        case ' ': {
+--          p++;
+--          goto s_n_llhttp__internal__n_header_value_te_chunked_last;
+--        }
+--        default: {
+--          goto s_n_llhttp__internal__n_header_value_te_chunked;
+--        }
+--      }
+-+    case s_n_llhttp__internal__n_error_30:
+-+    s_n_llhttp__internal__n_error_30: {
+-+      state->error = 0xf;
+-+      state->reason = "Invalid `Transfer-Encoding` header value";
+-+      state->error_pos = (const char*) p;
+-+      state->_current = (void*) (intptr_t) s_error;
+-+      return s_error;
+-+      /* UNREACHABLE */;
+-+      abort();
+-+    }
+-+    case s_n_llhttp__internal__n_error_29:
+-+    s_n_llhttp__internal__n_error_29: {
+-+      state->error = 0xf;
+-+      state->reason = "Invalid `Transfer-Encoding` header value";
+-+      state->error_pos = (const char*) p;
+-+      state->_current = (void*) (intptr_t) s_error;
+-+      return s_error;
+-       /* UNREACHABLE */;
+-       abort();
+-     }
+-@@ -2048,8 +2062,34 @@
+-           goto s_n_llhttp__internal__n_header_value_te_token_ows;
+-         }
+-         default: {
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_9;
+-+        }
+-+      }
+-+      /* UNREACHABLE */;
+-+      abort();
+-+    }
+-+    case s_n_llhttp__internal__n_header_value_te_chunked_last:
+-+    s_n_llhttp__internal__n_header_value_te_chunked_last: {
+-+      if (p == endp) {
+-+        return s_n_llhttp__internal__n_header_value_te_chunked_last;
+-+      }
+-+      switch (*p) {
+-+        case 10: {
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_8;
+-+        }
+-+        case 13: {
+-           goto s_n_llhttp__internal__n_invoke_update_header_state_8;
+-         }
+-+        case ' ': {
+-+          p++;
+-+          goto s_n_llhttp__internal__n_header_value_te_chunked_last;
+-+        }
+-+        case ',': {
+-+          goto s_n_llhttp__internal__n_invoke_load_type_1;
+-+        }
+-+        default: {
+-+          goto s_n_llhttp__internal__n_header_value_te_token;
+-+        }
+-       }
+-       /* UNREACHABLE */;
+-       abort();
+-@@ -2101,7 +2141,7 @@
+-         }
+-         case 10: {
+-           p++;
+--          goto s_n_llhttp__internal__n_header_value_discard_lws;
+-+          goto s_n_llhttp__internal__n_invoke_test_flags_5;
+-         }
+-         case 13: {
+-           p++;
+-@@ -2128,7 +2168,7 @@
+-           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_2;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_28;
+-+          goto s_n_llhttp__internal__n_error_31;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2218,7 +2258,7 @@
+-           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_9;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2243,7 +2283,7 @@
+-           return s_n_llhttp__internal__n_header_field_3;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2268,7 +2308,7 @@
+-           return s_n_llhttp__internal__n_header_field_4;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2289,7 +2329,7 @@
+-           goto s_n_llhttp__internal__n_header_field_4;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2313,7 +2353,7 @@
+-           return s_n_llhttp__internal__n_header_field_1;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2338,7 +2378,7 @@
+-           return s_n_llhttp__internal__n_header_field_5;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2363,7 +2403,7 @@
+-           return s_n_llhttp__internal__n_header_field_6;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2388,7 +2428,7 @@
+-           return s_n_llhttp__internal__n_header_field_7;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2417,7 +2457,7 @@
+-           goto s_n_llhttp__internal__n_header_field_7;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2508,7 +2548,7 @@
+-           goto s_n_llhttp__internal__n_url_to_http_09;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_29;
+-+          goto s_n_llhttp__internal__n_error_32;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2533,7 +2573,7 @@
+-           goto s_n_llhttp__internal__n_url_skip_lf_to_http09_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_29;
+-+          goto s_n_llhttp__internal__n_error_32;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2550,7 +2590,7 @@
+-           goto s_n_llhttp__internal__n_header_field_start;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_30;
+-+          goto s_n_llhttp__internal__n_error_33;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2571,7 +2611,7 @@
+-           goto s_n_llhttp__internal__n_req_http_end_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_30;
+-+          goto s_n_llhttp__internal__n_error_33;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2634,7 +2674,7 @@
+-           goto s_n_llhttp__internal__n_invoke_store_http_minor;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_31;
+-+          goto s_n_llhttp__internal__n_error_34;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2651,7 +2691,7 @@
+-           goto s_n_llhttp__internal__n_req_http_minor;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_32;
+-+          goto s_n_llhttp__internal__n_error_35;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2714,7 +2754,7 @@
+-           goto s_n_llhttp__internal__n_invoke_store_http_major;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_33;
+-+          goto s_n_llhttp__internal__n_error_36;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2738,7 +2778,7 @@
+-           return s_n_llhttp__internal__n_req_http_start_1;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_35;
+-+          goto s_n_llhttp__internal__n_error_38;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2762,7 +2802,7 @@
+-           return s_n_llhttp__internal__n_req_http_start_2;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_35;
+-+          goto s_n_llhttp__internal__n_error_38;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2787,7 +2827,7 @@
+-           goto s_n_llhttp__internal__n_req_http_start_2;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_35;
+-+          goto s_n_llhttp__internal__n_error_38;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2878,7 +2918,7 @@
+-           goto s_n_llhttp__internal__n_url_fragment;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_36;
+-+          goto s_n_llhttp__internal__n_error_39;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2939,7 +2979,7 @@
+-           goto s_n_llhttp__internal__n_span_end_stub_query_3;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_37;
+-+          goto s_n_llhttp__internal__n_error_40;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -2977,7 +3017,7 @@
+-           goto s_n_llhttp__internal__n_url_query;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_38;
+-+          goto s_n_llhttp__internal__n_error_41;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3102,10 +3142,10 @@
+-         }
+-         case 8: {
+-           p++;
+--          goto s_n_llhttp__internal__n_error_39;
+-+          goto s_n_llhttp__internal__n_error_42;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_40;
+-+          goto s_n_llhttp__internal__n_error_43;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3164,7 +3204,7 @@
+-           goto s_n_llhttp__internal__n_url_server_with_at;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_41;
+-+          goto s_n_llhttp__internal__n_error_44;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3181,7 +3221,7 @@
+-           goto s_n_llhttp__internal__n_url_server;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_43;
+-+          goto s_n_llhttp__internal__n_error_46;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3199,7 +3239,7 @@
+-         }
+-         case 10: {
+-           p++;
+--          goto s_n_llhttp__internal__n_error_42;
+-+          goto s_n_llhttp__internal__n_error_45;
+-         }
+-         case 12: {
+-           p++;
+-@@ -3207,18 +3247,18 @@
+-         }
+-         case 13: {
+-           p++;
+--          goto s_n_llhttp__internal__n_error_42;
+-+          goto s_n_llhttp__internal__n_error_45;
+-         }
+-         case ' ': {
+-           p++;
+--          goto s_n_llhttp__internal__n_error_42;
+-+          goto s_n_llhttp__internal__n_error_45;
+-         }
+-         case '/': {
+-           p++;
+-           goto s_n_llhttp__internal__n_url_schema_delim_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_43;
+-+          goto s_n_llhttp__internal__n_error_46;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3264,7 +3304,7 @@
+-         }
+-         case 2: {
+-           p++;
+--          goto s_n_llhttp__internal__n_error_42;
+-+          goto s_n_llhttp__internal__n_error_45;
+-         }
+-         case 3: {
+-           goto s_n_llhttp__internal__n_span_end_stub_schema;
+-@@ -3274,7 +3314,7 @@
+-           goto s_n_llhttp__internal__n_url_schema;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_44;
+-+          goto s_n_llhttp__internal__n_error_47;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3310,7 +3350,7 @@
+-         }
+-         case 2: {
+-           p++;
+--          goto s_n_llhttp__internal__n_error_42;
+-+          goto s_n_llhttp__internal__n_error_45;
+-         }
+-         case 3: {
+-           goto s_n_llhttp__internal__n_span_start_stub_path_2;
+-@@ -3319,7 +3359,7 @@
+-           goto s_n_llhttp__internal__n_url_schema;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_45;
+-+          goto s_n_llhttp__internal__n_error_48;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3417,7 +3457,7 @@
+-           goto s_n_llhttp__internal__n_req_spaces_before_url;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_46;
+-+          goto s_n_llhttp__internal__n_error_49;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3442,7 +3482,7 @@
+-           return s_n_llhttp__internal__n_start_req_1;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3467,7 +3507,7 @@
+-           return s_n_llhttp__internal__n_start_req_2;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3492,7 +3532,7 @@
+-           return s_n_llhttp__internal__n_start_req_4;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3517,7 +3557,7 @@
+-           return s_n_llhttp__internal__n_start_req_6;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3535,7 +3575,7 @@
+-           goto s_n_llhttp__internal__n_invoke_store_method_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3556,7 +3596,7 @@
+-           goto s_n_llhttp__internal__n_start_req_7;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3577,7 +3617,7 @@
+-           goto s_n_llhttp__internal__n_start_req_5;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3602,7 +3642,7 @@
+-           return s_n_llhttp__internal__n_start_req_8;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3627,7 +3667,7 @@
+-           return s_n_llhttp__internal__n_start_req_9;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3652,7 +3692,7 @@
+-           return s_n_llhttp__internal__n_start_req_10;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3677,7 +3717,7 @@
+-           return s_n_llhttp__internal__n_start_req_12;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3702,7 +3742,7 @@
+-           return s_n_llhttp__internal__n_start_req_13;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3723,7 +3763,7 @@
+-           goto s_n_llhttp__internal__n_start_req_13;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3748,7 +3788,7 @@
+-           return s_n_llhttp__internal__n_start_req_15;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3773,7 +3813,7 @@
+-           return s_n_llhttp__internal__n_start_req_16;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3798,7 +3838,7 @@
+-           return s_n_llhttp__internal__n_start_req_18;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3823,7 +3863,7 @@
+-           return s_n_llhttp__internal__n_start_req_20;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3841,7 +3881,7 @@
+-           goto s_n_llhttp__internal__n_invoke_store_method_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3862,7 +3902,7 @@
+-           goto s_n_llhttp__internal__n_start_req_21;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3883,7 +3923,7 @@
+-           goto s_n_llhttp__internal__n_start_req_19;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3908,7 +3948,7 @@
+-           return s_n_llhttp__internal__n_start_req_22;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3937,7 +3977,7 @@
+-           goto s_n_llhttp__internal__n_start_req_22;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3962,7 +4002,7 @@
+-           return s_n_llhttp__internal__n_start_req_23;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -3987,7 +4027,7 @@
+-           return s_n_llhttp__internal__n_start_req_24;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4012,7 +4052,7 @@
+-           return s_n_llhttp__internal__n_start_req_26;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4037,7 +4077,7 @@
+-           return s_n_llhttp__internal__n_start_req_27;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4062,7 +4102,7 @@
+-           return s_n_llhttp__internal__n_start_req_31;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4087,7 +4127,7 @@
+-           return s_n_llhttp__internal__n_start_req_32;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4108,7 +4148,7 @@
+-           goto s_n_llhttp__internal__n_start_req_32;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4125,7 +4165,7 @@
+-           goto s_n_llhttp__internal__n_start_req_30;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4147,7 +4187,7 @@
+-           goto s_n_llhttp__internal__n_start_req_29;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4172,7 +4212,7 @@
+-           return s_n_llhttp__internal__n_start_req_34;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4194,7 +4234,7 @@
+-           goto s_n_llhttp__internal__n_invoke_store_method_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4223,7 +4263,7 @@
+-           goto s_n_llhttp__internal__n_start_req_33;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4248,7 +4288,7 @@
+-           return s_n_llhttp__internal__n_start_req_37;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4273,7 +4313,7 @@
+-           return s_n_llhttp__internal__n_start_req_38;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4294,7 +4334,7 @@
+-           goto s_n_llhttp__internal__n_start_req_38;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4311,7 +4351,7 @@
+-           goto s_n_llhttp__internal__n_start_req_36;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4336,7 +4376,7 @@
+-           return s_n_llhttp__internal__n_start_req_40;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4361,7 +4401,7 @@
+-           return s_n_llhttp__internal__n_start_req_41;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4386,7 +4426,7 @@
+-           return s_n_llhttp__internal__n_start_req_42;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4411,7 +4451,7 @@
+-           goto s_n_llhttp__internal__n_start_req_42;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4436,7 +4476,7 @@
+-           return s_n_llhttp__internal__n_start_req_43;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4461,7 +4501,7 @@
+-           return s_n_llhttp__internal__n_start_req_46;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4486,7 +4526,7 @@
+-           return s_n_llhttp__internal__n_start_req_48;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4511,7 +4551,7 @@
+-           return s_n_llhttp__internal__n_start_req_49;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4532,7 +4572,7 @@
+-           goto s_n_llhttp__internal__n_start_req_49;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4557,7 +4597,7 @@
+-           return s_n_llhttp__internal__n_start_req_50;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4582,7 +4622,7 @@
+-           goto s_n_llhttp__internal__n_start_req_50;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4599,7 +4639,7 @@
+-           goto s_n_llhttp__internal__n_start_req_45;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4672,7 +4712,7 @@
+-           goto s_n_llhttp__internal__n_start_req_44;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_55;
+-+          goto s_n_llhttp__internal__n_error_58;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4689,7 +4729,7 @@
+-           goto s_n_llhttp__internal__n_header_field_start;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4764,7 +4804,7 @@
+-           goto s_n_llhttp__internal__n_res_status_start;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_49;
+-+          goto s_n_llhttp__internal__n_error_52;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4844,7 +4884,7 @@
+-           goto s_n_llhttp__internal__n_invoke_update_status_code;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_50;
+-+          goto s_n_llhttp__internal__n_error_53;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4907,7 +4947,7 @@
+-           goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_51;
+-+          goto s_n_llhttp__internal__n_error_54;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4924,7 +4964,7 @@
+-           goto s_n_llhttp__internal__n_res_http_minor;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_52;
+-+          goto s_n_llhttp__internal__n_error_55;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -4987,7 +5027,7 @@
+-           goto s_n_llhttp__internal__n_invoke_store_http_major_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_53;
+-+          goto s_n_llhttp__internal__n_error_56;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -5011,7 +5051,7 @@
+-           return s_n_llhttp__internal__n_start_res;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_56;
+-+          goto s_n_llhttp__internal__n_error_59;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -5036,7 +5076,7 @@
+-           return s_n_llhttp__internal__n_req_or_res_method_2;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_54;
+-+          goto s_n_llhttp__internal__n_error_57;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -5060,7 +5100,7 @@
+-           return s_n_llhttp__internal__n_req_or_res_method_3;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_54;
+-+          goto s_n_llhttp__internal__n_error_57;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -5081,7 +5121,7 @@
+-           goto s_n_llhttp__internal__n_req_or_res_method_3;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_54;
+-+          goto s_n_llhttp__internal__n_error_57;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -5098,7 +5138,7 @@
+-           goto s_n_llhttp__internal__n_req_or_res_method_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_54;
+-+          goto s_n_llhttp__internal__n_error_57;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -5167,7 +5207,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_42: {
+-+  s_n_llhttp__internal__n_error_45: {
+-     state->error = 0x7;
+-     state->reason = "Invalid characters in url";
+-     state->error_pos = (const char*) p;
+-@@ -5655,7 +5695,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_21: {
+-+  s_n_llhttp__internal__n_error_22: {
+-     state->error = 0xb;
+-     state->reason = "Empty Content-Length";
+-     state->error_pos = (const char*) p;
+-@@ -5740,14 +5780,33 @@
+-   s_n_llhttp__internal__n_invoke_load_header_state: {
+-     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
+-       case 2:
+--        goto s_n_llhttp__internal__n_error_21;
+-+        goto s_n_llhttp__internal__n_error_22;
+-       default:
+-         goto s_n_llhttp__internal__n_invoke_load_header_state_1;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_22: {
+-+  s_n_llhttp__internal__n_error_21: {
+-+    state->error = 0xa;
+-+    state->reason = "Invalid header value char";
+-+    state->error_pos = (const char*) p;
+-+    state->_current = (void*) (intptr_t) s_error;
+-+    return s_error;
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_test_flags_5: {
+-+    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+-+      case 1:
+-+        goto s_n_llhttp__internal__n_header_value_discard_lws;
+-+      default:
+-+        goto s_n_llhttp__internal__n_error_21;
+-+    }
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_error_23: {
+-     state->error = 0x2;
+-     state->reason = "Expected LF after CR";
+-     state->error_pos = (const char*) p;
+-@@ -5757,6 +5816,24 @@
+-     abort();
+-   }
+-   s_n_llhttp__internal__n_invoke_update_header_state_1: {
+-+    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
+-+      default:
+-+        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+-+    }
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_load_header_state_3: {
+-+    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
+-+      case 8:
+-+        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+-+      default:
+-+        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+-+    }
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_update_header_state_2: {
+-     switch (llhttp__internal__c_update_header_state(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_field_start;
+-@@ -5767,7 +5844,7 @@
+-   s_n_llhttp__internal__n_invoke_or_flags_7: {
+-     switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
+-       default:
+--        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+-+        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-@@ -5775,7 +5852,7 @@
+-   s_n_llhttp__internal__n_invoke_or_flags_8: {
+-     switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
+-       default:
+--        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+-+        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-@@ -5783,7 +5860,7 @@
+-   s_n_llhttp__internal__n_invoke_or_flags_9: {
+-     switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
+-       default:
+--        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+-+        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-@@ -5796,7 +5873,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_load_header_state_3: {
+-+  s_n_llhttp__internal__n_invoke_load_header_state_4: {
+-     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
+-       case 5:
+-         goto s_n_llhttp__internal__n_invoke_or_flags_7;
+-@@ -5812,7 +5889,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_23: {
+-+  s_n_llhttp__internal__n_error_24: {
+-     state->error = 0x3;
+-     state->reason = "Missing expected LF after header value";
+-     state->error_pos = (const char*) p;
+-@@ -5830,6 +5907,24 @@
+-     err = llhttp__on_header_value(state, start, p);
+-     if (err != 0) {
+-       state->error = err;
+-+      state->error_pos = (const char*) (p + 1);
+-+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
+-+      return s_error;
+-+    }
+-+    p++;
+-+    goto s_n_llhttp__internal__n_header_value_almost_done;
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3: {
+-+    const unsigned char* start;
+-+    int err;
+-+    
+-+    start = state->_span_pos0;
+-+    state->_span_pos0 = NULL;
+-+    err = llhttp__on_header_value(state, start, p);
+-+    if (err != 0) {
+-+      state->error = err;
+-       state->error_pos = (const char*) p;
+-       state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
+-       return s_error;
+-@@ -5838,7 +5933,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2: {
+-+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4: {
+-     const unsigned char* start;
+-     int err;
+-     
+-@@ -5856,7 +5951,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3: {
+-+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2: {
+-     const unsigned char* start;
+-     int err;
+-     
+-@@ -5865,35 +5960,25 @@
+-     err = llhttp__on_header_value(state, start, p);
+-     if (err != 0) {
+-       state->error = err;
+--      state->error_pos = (const char*) (p + 1);
+--      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
+-+      state->error_pos = (const char*) p;
+-+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_25;
+-       return s_error;
+-     }
+--    p++;
+--    goto s_n_llhttp__internal__n_header_value_almost_done;
+--    /* UNREACHABLE */;
+--    abort();
+--  }
+--  s_n_llhttp__internal__n_error_24: {
+--    state->error = 0xa;
+--    state->reason = "Invalid header value char";
+--    state->error_pos = (const char*) p;
+--    state->_current = (void*) (intptr_t) s_error;
+--    return s_error;
+-+    goto s_n_llhttp__internal__n_error_25;
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_test_flags_5: {
+-+  s_n_llhttp__internal__n_invoke_test_flags_6: {
+-     switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+-       case 1:
+-         goto s_n_llhttp__internal__n_header_value_lenient;
+-       default:
+--        goto s_n_llhttp__internal__n_error_24;
+-+        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_update_header_state_3: {
+-+  s_n_llhttp__internal__n_invoke_update_header_state_4: {
+-     switch (llhttp__internal__c_update_header_state(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_value_connection;
+-@@ -5904,7 +5989,7 @@
+-   s_n_llhttp__internal__n_invoke_or_flags_11: {
+-     switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
+-       default:
+--        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+-+        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-@@ -5912,7 +5997,7 @@
+-   s_n_llhttp__internal__n_invoke_or_flags_12: {
+-     switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
+-       default:
+--        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+-+        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-@@ -5920,7 +6005,7 @@
+-   s_n_llhttp__internal__n_invoke_or_flags_13: {
+-     switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
+-       default:
+--        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+-+        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-@@ -5933,7 +6018,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_load_header_state_4: {
+-+  s_n_llhttp__internal__n_invoke_load_header_state_5: {
+-     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
+-       case 5:
+-         goto s_n_llhttp__internal__n_invoke_or_flags_11;
+-@@ -5949,39 +6034,39 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_update_header_state_4: {
+--    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+-+  s_n_llhttp__internal__n_invoke_update_header_state_5: {
+-+    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_value_connection_token;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_update_header_state_2: {
+--    switch (llhttp__internal__c_update_header_state_2(state, p, endp)) {
+-+  s_n_llhttp__internal__n_invoke_update_header_state_3: {
+-+    switch (llhttp__internal__c_update_header_state_3(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_value_connection_ws;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_update_header_state_5: {
+--    switch (llhttp__internal__c_update_header_state_5(state, p, endp)) {
+-+  s_n_llhttp__internal__n_invoke_update_header_state_6: {
+-+    switch (llhttp__internal__c_update_header_state_6(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_value_connection_ws;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_update_header_state_6: {
+--    switch (llhttp__internal__c_update_header_state_6(state, p, endp)) {
+-+  s_n_llhttp__internal__n_invoke_update_header_state_7: {
+-+    switch (llhttp__internal__c_update_header_state_7(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_value_connection_ws;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4: {
+-+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5: {
+-     const unsigned char* start;
+-     int err;
+-     
+-@@ -5991,17 +6076,17 @@
+-     if (err != 0) {
+-       state->error = err;
+-       state->error_pos = (const char*) p;
+--      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_26;
+-+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_27;
+-       return s_error;
+-     }
+--    goto s_n_llhttp__internal__n_error_26;
+-+    goto s_n_llhttp__internal__n_error_27;
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+-   s_n_llhttp__internal__n_invoke_mul_add_content_length_1: {
+-     switch (llhttp__internal__c_mul_add_content_length_1(state, p, endp, match)) {
+-       case 1:
+--        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4;
+-+        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5;
+-       default:
+-         goto s_n_llhttp__internal__n_header_value_content_length;
+-     }
+-@@ -6016,7 +6101,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5: {
+-+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_6: {
+-     const unsigned char* start;
+-     int err;
+-     
+-@@ -6026,14 +6111,14 @@
+-     if (err != 0) {
+-       state->error = err;
+-       state->error_pos = (const char*) p;
+--      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_27;
+-+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_28;
+-       return s_error;
+-     }
+--    goto s_n_llhttp__internal__n_error_27;
+-+    goto s_n_llhttp__internal__n_error_28;
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_25: {
+-+  s_n_llhttp__internal__n_error_26: {
+-     state->error = 0x4;
+-     state->reason = "Duplicate Content-Length";
+-     state->error_pos = (const char*) p;
+-@@ -6042,26 +6127,82 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_test_flags_6: {
+--    switch (llhttp__internal__c_test_flags_6(state, p, endp)) {
+-+  s_n_llhttp__internal__n_invoke_test_flags_7: {
+-+    switch (llhttp__internal__c_test_flags_7(state, p, endp)) {
+-       case 0:
+-         goto s_n_llhttp__internal__n_header_value_content_length;
+-       default:
+--        goto s_n_llhttp__internal__n_error_25;
+-+        goto s_n_llhttp__internal__n_error_26;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_update_header_state_7: {
+--    switch (llhttp__internal__c_update_header_state_7(state, p, endp)) {
+-+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_8: {
+-+    const unsigned char* start;
+-+    int err;
+-+    
+-+    start = state->_span_pos0;
+-+    state->_span_pos0 = NULL;
+-+    err = llhttp__on_header_value(state, start, p);
+-+    if (err != 0) {
+-+      state->error = err;
+-+      state->error_pos = (const char*) (p + 1);
+-+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_30;
+-+      return s_error;
+-+    }
+-+    p++;
+-+    goto s_n_llhttp__internal__n_error_30;
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_update_header_state_8: {
+-+    switch (llhttp__internal__c_update_header_state_8(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_value_otherwise;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_update_header_state_8: {
+--    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+-+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_7: {
+-+    const unsigned char* start;
+-+    int err;
+-+    
+-+    start = state->_span_pos0;
+-+    state->_span_pos0 = NULL;
+-+    err = llhttp__on_header_value(state, start, p);
+-+    if (err != 0) {
+-+      state->error = err;
+-+      state->error_pos = (const char*) (p + 1);
+-+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_29;
+-+      return s_error;
+-+    }
+-+    p++;
+-+    goto s_n_llhttp__internal__n_error_29;
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_test_flags_9: {
+-+    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+-+      case 0:
+-+        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_7;
+-+      default:
+-+        goto s_n_llhttp__internal__n_header_value_te_chunked;
+-+    }
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_load_type_1: {
+-+    switch (llhttp__internal__c_load_type(state, p, endp)) {
+-+      case 1:
+-+        goto s_n_llhttp__internal__n_invoke_test_flags_9;
+-+      default:
+-+        goto s_n_llhttp__internal__n_header_value_te_chunked;
+-+    }
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_update_header_state_9: {
+-+    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_value;
+-     }
+-@@ -6076,6 +6217,34 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+-+  s_n_llhttp__internal__n_invoke_or_flags_17: {
+-+    switch (llhttp__internal__c_or_flags_16(state, p, endp)) {
+-+      default:
+-+        goto s_n_llhttp__internal__n_invoke_and_flags;
+-+    }
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_test_flags_10: {
+-+    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+-+      case 0:
+-+        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_8;
+-+      default:
+-+        goto s_n_llhttp__internal__n_invoke_or_flags_17;
+-+    }
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_load_type_2: {
+-+    switch (llhttp__internal__c_load_type(state, p, endp)) {
+-+      case 1:
+-+        goto s_n_llhttp__internal__n_invoke_test_flags_10;
+-+      default:
+-+        goto s_n_llhttp__internal__n_invoke_or_flags_17;
+-+    }
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-   s_n_llhttp__internal__n_invoke_or_flags_16: {
+-     switch (llhttp__internal__c_or_flags_16(state, p, endp)) {
+-       default:
+-@@ -6084,10 +6253,20 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_or_flags_17: {
+--    switch (llhttp__internal__c_or_flags_17(state, p, endp)) {
+-+  s_n_llhttp__internal__n_invoke_test_flags_8: {
+-+    switch (llhttp__internal__c_test_flags_8(state, p, endp)) {
+-+      case 1:
+-+        goto s_n_llhttp__internal__n_invoke_load_type_2;
+-       default:
+--        goto s_n_llhttp__internal__n_invoke_update_header_state_8;
+-+        goto s_n_llhttp__internal__n_invoke_or_flags_16;
+-+    }
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_or_flags_18: {
+-+    switch (llhttp__internal__c_or_flags_18(state, p, endp)) {
+-+      default:
+-+        goto s_n_llhttp__internal__n_invoke_update_header_state_9;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-@@ -6097,11 +6276,11 @@
+-       case 1:
+-         goto s_n_llhttp__internal__n_header_value_connection;
+-       case 2:
+--        goto s_n_llhttp__internal__n_invoke_test_flags_6;
+-+        goto s_n_llhttp__internal__n_invoke_test_flags_7;
+-       case 3:
+--        goto s_n_llhttp__internal__n_invoke_or_flags_16;
+-+        goto s_n_llhttp__internal__n_invoke_test_flags_8;
+-       case 4:
+--        goto s_n_llhttp__internal__n_invoke_or_flags_17;
+-+        goto s_n_llhttp__internal__n_invoke_or_flags_18;
+-       default:
+-         goto s_n_llhttp__internal__n_header_value;
+-     }
+-@@ -6144,7 +6323,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_28: {
+-+  s_n_llhttp__internal__n_error_31: {
+-     state->error = 0xa;
+-     state->reason = "Invalid header token";
+-     state->error_pos = (const char*) p;
+-@@ -6153,8 +6332,8 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_update_header_state_9: {
+--    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+-+  s_n_llhttp__internal__n_invoke_update_header_state_10: {
+-+    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_field_general;
+-     }
+-@@ -6169,8 +6348,8 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_update_header_state_10: {
+--    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+-+  s_n_llhttp__internal__n_invoke_update_header_state_11: {
+-+    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_field_general;
+-     }
+-@@ -6210,7 +6389,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_29: {
+-+  s_n_llhttp__internal__n_error_32: {
+-     state->error = 0x7;
+-     state->reason = "Expected CRLF";
+-     state->error_pos = (const char*) p;
+-@@ -6236,7 +6415,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_30: {
+-+  s_n_llhttp__internal__n_error_33: {
+-     state->error = 0x9;
+-     state->reason = "Expected CRLF after version";
+-     state->error_pos = (const char*) p;
+-@@ -6253,7 +6432,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_31: {
+-+  s_n_llhttp__internal__n_error_34: {
+-     state->error = 0x9;
+-     state->reason = "Invalid minor version";
+-     state->error_pos = (const char*) p;
+-@@ -6262,7 +6441,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_32: {
+-+  s_n_llhttp__internal__n_error_35: {
+-     state->error = 0x9;
+-     state->reason = "Expected dot";
+-     state->error_pos = (const char*) p;
+-@@ -6279,7 +6458,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_33: {
+-+  s_n_llhttp__internal__n_error_36: {
+-     state->error = 0x9;
+-     state->reason = "Invalid major version";
+-     state->error_pos = (const char*) p;
+-@@ -6288,7 +6467,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_35: {
+-+  s_n_llhttp__internal__n_error_38: {
+-     state->error = 0x8;
+-     state->reason = "Expected HTTP/";
+-     state->error_pos = (const char*) p;
+-@@ -6297,7 +6476,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_34: {
+-+  s_n_llhttp__internal__n_error_37: {
+-     state->error = 0x8;
+-     state->reason = "Expected SOURCE method for ICE/x.x request";
+-     state->error_pos = (const char*) p;
+-@@ -6309,7 +6488,7 @@
+-   s_n_llhttp__internal__n_invoke_is_equal_method_1: {
+-     switch (llhttp__internal__c_is_equal_method_1(state, p, endp)) {
+-       case 0:
+--        goto s_n_llhttp__internal__n_error_34;
+-+        goto s_n_llhttp__internal__n_error_37;
+-       default:
+-         goto s_n_llhttp__internal__n_req_http_major;
+-     }
+-@@ -6384,7 +6563,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_36: {
+-+  s_n_llhttp__internal__n_error_39: {
+-     state->error = 0x7;
+-     state->reason = "Invalid char in url fragment start";
+-     state->error_pos = (const char*) p;
+-@@ -6444,7 +6623,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_37: {
+-+  s_n_llhttp__internal__n_error_40: {
+-     state->error = 0x7;
+-     state->reason = "Invalid char in url query";
+-     state->error_pos = (const char*) p;
+-@@ -6453,7 +6632,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_38: {
+-+  s_n_llhttp__internal__n_error_41: {
+-     state->error = 0x7;
+-     state->reason = "Invalid char in url path";
+-     state->error_pos = (const char*) p;
+-@@ -6564,7 +6743,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_39: {
+-+  s_n_llhttp__internal__n_error_42: {
+-     state->error = 0x7;
+-     state->reason = "Double @ in url";
+-     state->error_pos = (const char*) p;
+-@@ -6573,7 +6752,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_40: {
+-+  s_n_llhttp__internal__n_error_43: {
+-     state->error = 0x7;
+-     state->reason = "Unexpected char in url server";
+-     state->error_pos = (const char*) p;
+-@@ -6582,7 +6761,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_41: {
+-+  s_n_llhttp__internal__n_error_44: {
+-     state->error = 0x7;
+-     state->reason = "Unexpected char in url server";
+-     state->error_pos = (const char*) p;
+-@@ -6591,7 +6770,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_43: {
+-+  s_n_llhttp__internal__n_error_46: {
+-     state->error = 0x7;
+-     state->reason = "Unexpected char in url schema";
+-     state->error_pos = (const char*) p;
+-@@ -6600,7 +6779,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_44: {
+-+  s_n_llhttp__internal__n_error_47: {
+-     state->error = 0x7;
+-     state->reason = "Unexpected char in url schema";
+-     state->error_pos = (const char*) p;
+-@@ -6609,7 +6788,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_45: {
+-+  s_n_llhttp__internal__n_error_48: {
+-     state->error = 0x7;
+-     state->reason = "Unexpected start char in url";
+-     state->error_pos = (const char*) p;
+-@@ -6628,7 +6807,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_46: {
+-+  s_n_llhttp__internal__n_error_49: {
+-     state->error = 0x6;
+-     state->reason = "Expected space after method";
+-     state->error_pos = (const char*) p;
+-@@ -6645,7 +6824,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_55: {
+-+  s_n_llhttp__internal__n_error_58: {
+-     state->error = 0x6;
+-     state->reason = "Invalid method encountered";
+-     state->error_pos = (const char*) p;
+-@@ -6654,7 +6833,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_47: {
+-+  s_n_llhttp__internal__n_error_50: {
+-     state->error = 0xd;
+-     state->reason = "Response overflow";
+-     state->error_pos = (const char*) p;
+-@@ -6666,14 +6845,14 @@
+-   s_n_llhttp__internal__n_invoke_mul_add_status_code: {
+-     switch (llhttp__internal__c_mul_add_status_code(state, p, endp, match)) {
+-       case 1:
+--        goto s_n_llhttp__internal__n_error_47;
+-+        goto s_n_llhttp__internal__n_error_50;
+-       default:
+-         goto s_n_llhttp__internal__n_res_status_code;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_48: {
+-+  s_n_llhttp__internal__n_error_51: {
+-     state->error = 0x2;
+-     state->reason = "Expected LF after CR";
+-     state->error_pos = (const char*) p;
+-@@ -6718,7 +6897,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_49: {
+-+  s_n_llhttp__internal__n_error_52: {
+-     state->error = 0xd;
+-     state->reason = "Invalid response status";
+-     state->error_pos = (const char*) p;
+-@@ -6735,7 +6914,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_50: {
+-+  s_n_llhttp__internal__n_error_53: {
+-     state->error = 0x9;
+-     state->reason = "Expected space after version";
+-     state->error_pos = (const char*) p;
+-@@ -6752,7 +6931,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_51: {
+-+  s_n_llhttp__internal__n_error_54: {
+-     state->error = 0x9;
+-     state->reason = "Invalid minor version";
+-     state->error_pos = (const char*) p;
+-@@ -6761,7 +6940,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_52: {
+-+  s_n_llhttp__internal__n_error_55: {
+-     state->error = 0x9;
+-     state->reason = "Expected dot";
+-     state->error_pos = (const char*) p;
+-@@ -6778,7 +6957,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_53: {
+-+  s_n_llhttp__internal__n_error_56: {
+-     state->error = 0x9;
+-     state->reason = "Invalid major version";
+-     state->error_pos = (const char*) p;
+-@@ -6787,7 +6966,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_56: {
+-+  s_n_llhttp__internal__n_error_59: {
+-     state->error = 0x8;
+-     state->reason = "Expected HTTP/";
+-     state->error_pos = (const char*) p;
+-@@ -6812,7 +6991,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_54: {
+-+  s_n_llhttp__internal__n_error_57: {
+-     state->error = 0x8;
+-     state->reason = "Invalid word encountered";
+-     state->error_pos = (const char*) p;
+-@@ -7244,6 +7423,7 @@
+-   s_n_llhttp__internal__n_header_value_lws,
+-   s_n_llhttp__internal__n_header_value_almost_done,
+-   s_n_llhttp__internal__n_header_value_lenient,
+-+  s_n_llhttp__internal__n_error_19,
+-   s_n_llhttp__internal__n_header_value_otherwise,
+-   s_n_llhttp__internal__n_header_value_connection_token,
+-   s_n_llhttp__internal__n_header_value_connection_ws,
+-@@ -7251,14 +7431,16 @@
+-   s_n_llhttp__internal__n_header_value_connection_2,
+-   s_n_llhttp__internal__n_header_value_connection_3,
+-   s_n_llhttp__internal__n_header_value_connection,
+--  s_n_llhttp__internal__n_error_20,
+-   s_n_llhttp__internal__n_error_21,
+-+  s_n_llhttp__internal__n_error_22,
+-   s_n_llhttp__internal__n_header_value_content_length_ws,
+-   s_n_llhttp__internal__n_header_value_content_length,
+--  s_n_llhttp__internal__n_header_value_te_chunked_last,
+-+  s_n_llhttp__internal__n_error_24,
+-+  s_n_llhttp__internal__n_error_23,
+-   s_n_llhttp__internal__n_header_value_te_token_ows,
+-   s_n_llhttp__internal__n_header_value,
+-   s_n_llhttp__internal__n_header_value_te_token,
+-+  s_n_llhttp__internal__n_header_value_te_chunked_last,
+-   s_n_llhttp__internal__n_header_value_te_chunked,
+-   s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1,
+-   s_n_llhttp__internal__n_header_value_discard_ws,
+-@@ -7648,7 +7830,7 @@
+-   return 0;
+- }
+- 
+--int llhttp__internal__c_update_header_state_2(
+-+int llhttp__internal__c_update_header_state_3(
+-     llhttp__internal_t* state,
+-     const unsigned char* p,
+-     const unsigned char* endp) {
+-@@ -7656,7 +7838,7 @@
+-   return 0;
+- }
+- 
+--int llhttp__internal__c_update_header_state_4(
+-+int llhttp__internal__c_update_header_state_1(
+-     llhttp__internal_t* state,
+-     const unsigned char* p,
+-     const unsigned char* endp) {
+-@@ -7664,7 +7846,7 @@
+-   return 0;
+- }
+- 
+--int llhttp__internal__c_update_header_state_5(
+-+int llhttp__internal__c_update_header_state_6(
+-     llhttp__internal_t* state,
+-     const unsigned char* p,
+-     const unsigned char* endp) {
+-@@ -7672,7 +7854,7 @@
+-   return 0;
+- }
+- 
+--int llhttp__internal__c_update_header_state_6(
+-+int llhttp__internal__c_update_header_state_7(
+-     llhttp__internal_t* state,
+-     const unsigned char* p,
+-     const unsigned char* endp) {
+-@@ -7680,7 +7862,7 @@
+-   return 0;
+- }
+- 
+--int llhttp__internal__c_test_flags_6(
+-+int llhttp__internal__c_test_flags_7(
+-     llhttp__internal_t* state,
+-     const unsigned char* p,
+-     const unsigned char* endp) {
+-@@ -7721,6 +7903,13 @@
+-   return 0;
+- }
+- 
+-+int llhttp__internal__c_test_flags_8(
+-+    llhttp__internal_t* state,
+-+    const unsigned char* p,
+-+    const unsigned char* endp) {
+-+  return (state->flags & 8) == 8;
+-+}
+-+
+- int llhttp__internal__c_or_flags_16(
+-     llhttp__internal_t* state,
+-     const unsigned char* p,
+-@@ -7737,7 +7926,7 @@
+-   return 0;
+- }
+- 
+--int llhttp__internal__c_update_header_state_7(
+-+int llhttp__internal__c_update_header_state_8(
+-     llhttp__internal_t* state,
+-     const unsigned char* p,
+-     const unsigned char* endp) {
+-@@ -7745,7 +7934,7 @@
+-   return 0;
+- }
+- 
+--int llhttp__internal__c_or_flags_17(
+-+int llhttp__internal__c_or_flags_18(
+-     llhttp__internal_t* state,
+-     const unsigned char* p,
+-     const unsigned char* endp) {
+-@@ -8432,13 +8621,13 @@
+-       }
+-       switch (*p) {
+-         case 9: {
+--          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+-+          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
+-         }
+-         case ' ': {
+--          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+-+          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
+-+          goto s_n_llhttp__internal__n_invoke_load_header_state_4;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -8455,7 +8644,7 @@
+-           goto s_n_llhttp__internal__n_header_value_lws;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_17;
+-+          goto s_n_llhttp__internal__n_error_18;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -8468,10 +8657,10 @@
+-       }
+-       switch (*p) {
+-         case 10: {
+--          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
+-+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3;
+-         }
+-         case 13: {
+--          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3;
+-+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4;
+-         }
+-         default: {
+-           p++;
+-@@ -8481,20 +8670,27 @@
+-       /* UNREACHABLE */;
+-       abort();
+-     }
+-+    case s_n_llhttp__internal__n_error_19:
+-+    s_n_llhttp__internal__n_error_19: {
+-+      state->error = 0xa;
+-+      state->reason = "Invalid header value char";
+-+      state->error_pos = (const char*) p;
+-+      state->_current = (void*) (intptr_t) s_error;
+-+      return s_error;
+-+      /* UNREACHABLE */;
+-+      abort();
+-+    }
+-     case s_n_llhttp__internal__n_header_value_otherwise:
+-     s_n_llhttp__internal__n_header_value_otherwise: {
+-       if (p == endp) {
+-         return s_n_llhttp__internal__n_header_value_otherwise;
+-       }
+-       switch (*p) {
+--        case 10: {
+--          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
+--        }
+-         case 13: {
+--          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2;
+-+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_invoke_test_flags_5;
+-+          goto s_n_llhttp__internal__n_invoke_test_flags_6;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -8557,10 +8753,10 @@
+-         }
+-         case ',': {
+-           p++;
+--          goto s_n_llhttp__internal__n_invoke_load_header_state_4;
+-+          goto s_n_llhttp__internal__n_invoke_load_header_state_5;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_4;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_5;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -8578,7 +8774,7 @@
+-       switch (match_seq.status) {
+-         case kMatchComplete: {
+-           p++;
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_2;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+-         }
+-         case kMatchPause: {
+-           return s_n_llhttp__internal__n_header_value_connection_1;
+-@@ -8602,7 +8798,7 @@
+-       switch (match_seq.status) {
+-         case kMatchComplete: {
+-           p++;
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_5;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_6;
+-         }
+-         case kMatchPause: {
+-           return s_n_llhttp__internal__n_header_value_connection_2;
+-@@ -8626,7 +8822,7 @@
+-       switch (match_seq.status) {
+-         case kMatchComplete: {
+-           p++;
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_6;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
+-         }
+-         case kMatchPause: {
+-           return s_n_llhttp__internal__n_header_value_connection_3;
+-@@ -8671,8 +8867,8 @@
+-       /* UNREACHABLE */;
+-       abort();
+-     }
+--    case s_n_llhttp__internal__n_error_20:
+--    s_n_llhttp__internal__n_error_20: {
+-+    case s_n_llhttp__internal__n_error_21:
+-+    s_n_llhttp__internal__n_error_21: {
+-       state->error = 0xb;
+-       state->reason = "Content-Length overflow";
+-       state->error_pos = (const char*) p;
+-@@ -8681,8 +8877,8 @@
+-       /* UNREACHABLE */;
+-       abort();
+-     }
+--    case s_n_llhttp__internal__n_error_21:
+--    s_n_llhttp__internal__n_error_21: {
+-+    case s_n_llhttp__internal__n_error_22:
+-+    s_n_llhttp__internal__n_error_22: {
+-       state->error = 0xb;
+-       state->reason = "Invalid character in Content-Length";
+-       state->error_pos = (const char*) p;
+-@@ -8708,7 +8904,7 @@
+-           goto s_n_llhttp__internal__n_header_value_content_length_ws;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5;
+-+          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_6;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -8777,26 +8973,23 @@
+-       /* UNREACHABLE */;
+-       abort();
+-     }
+--    case s_n_llhttp__internal__n_header_value_te_chunked_last:
+--    s_n_llhttp__internal__n_header_value_te_chunked_last: {
+--      if (p == endp) {
+--        return s_n_llhttp__internal__n_header_value_te_chunked_last;
+--      }
+--      switch (*p) {
+--        case 10: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
+--        }
+--        case 13: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
+--        }
+--        case ' ': {
+--          p++;
+--          goto s_n_llhttp__internal__n_header_value_te_chunked_last;
+--        }
+--        default: {
+--          goto s_n_llhttp__internal__n_header_value_te_chunked;
+--        }
+--      }
+-+    case s_n_llhttp__internal__n_error_24:
+-+    s_n_llhttp__internal__n_error_24: {
+-+      state->error = 0xf;
+-+      state->reason = "Invalid `Transfer-Encoding` header value";
+-+      state->error_pos = (const char*) p;
+-+      state->_current = (void*) (intptr_t) s_error;
+-+      return s_error;
+-+      /* UNREACHABLE */;
+-+      abort();
+-+    }
+-+    case s_n_llhttp__internal__n_error_23:
+-+    s_n_llhttp__internal__n_error_23: {
+-+      state->error = 0xf;
+-+      state->reason = "Invalid `Transfer-Encoding` header value";
+-+      state->error_pos = (const char*) p;
+-+      state->_current = (void*) (intptr_t) s_error;
+-+      return s_error;
+-       /* UNREACHABLE */;
+-       abort();
+-     }
+-@@ -8913,8 +9106,34 @@
+-           goto s_n_llhttp__internal__n_header_value_te_token_ows;
+-         }
+-         default: {
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_9;
+-+        }
+-+      }
+-+      /* UNREACHABLE */;
+-+      abort();
+-+    }
+-+    case s_n_llhttp__internal__n_header_value_te_chunked_last:
+-+    s_n_llhttp__internal__n_header_value_te_chunked_last: {
+-+      if (p == endp) {
+-+        return s_n_llhttp__internal__n_header_value_te_chunked_last;
+-+      }
+-+      switch (*p) {
+-+        case 10: {
+-           goto s_n_llhttp__internal__n_invoke_update_header_state_8;
+-         }
+-+        case 13: {
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_8;
+-+        }
+-+        case ' ': {
+-+          p++;
+-+          goto s_n_llhttp__internal__n_header_value_te_chunked_last;
+-+        }
+-+        case ',': {
+-+          goto s_n_llhttp__internal__n_invoke_load_type_1;
+-+        }
+-+        default: {
+-+          goto s_n_llhttp__internal__n_header_value_te_token;
+-+        }
+-       }
+-       /* UNREACHABLE */;
+-       abort();
+-@@ -8966,7 +9185,7 @@
+-         }
+-         case 10: {
+-           p++;
+--          goto s_n_llhttp__internal__n_header_value_discard_lws;
+-+          goto s_n_llhttp__internal__n_invoke_test_flags_5;
+-         }
+-         case 13: {
+-           p++;
+-@@ -8993,7 +9212,7 @@
+-           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_2;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_22;
+-+          goto s_n_llhttp__internal__n_error_25;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9083,7 +9302,7 @@
+-           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_9;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9108,7 +9327,7 @@
+-           return s_n_llhttp__internal__n_header_field_3;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9133,7 +9352,7 @@
+-           return s_n_llhttp__internal__n_header_field_4;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9154,7 +9373,7 @@
+-           goto s_n_llhttp__internal__n_header_field_4;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9178,7 +9397,7 @@
+-           return s_n_llhttp__internal__n_header_field_1;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9203,7 +9422,7 @@
+-           return s_n_llhttp__internal__n_header_field_5;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9228,7 +9447,7 @@
+-           return s_n_llhttp__internal__n_header_field_6;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9253,7 +9472,7 @@
+-           return s_n_llhttp__internal__n_header_field_7;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9282,7 +9501,7 @@
+-           goto s_n_llhttp__internal__n_header_field_7;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+-+          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9347,7 +9566,7 @@
+-           return s_n_llhttp__internal__n_url_skip_lf_to_http09;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_23;
+-+          goto s_n_llhttp__internal__n_error_26;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9364,7 +9583,7 @@
+-           goto s_n_llhttp__internal__n_header_field_start;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_24;
+-+          goto s_n_llhttp__internal__n_error_27;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9385,7 +9604,7 @@
+-           goto s_n_llhttp__internal__n_req_http_end_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_24;
+-+          goto s_n_llhttp__internal__n_error_27;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9448,7 +9667,7 @@
+-           goto s_n_llhttp__internal__n_invoke_store_http_minor;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_25;
+-+          goto s_n_llhttp__internal__n_error_28;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9465,7 +9684,7 @@
+-           goto s_n_llhttp__internal__n_req_http_minor;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_26;
+-+          goto s_n_llhttp__internal__n_error_29;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9528,7 +9747,7 @@
+-           goto s_n_llhttp__internal__n_invoke_store_http_major;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_27;
+-+          goto s_n_llhttp__internal__n_error_30;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9552,7 +9771,7 @@
+-           return s_n_llhttp__internal__n_req_http_start_1;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_29;
+-+          goto s_n_llhttp__internal__n_error_32;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9576,7 +9795,7 @@
+-           return s_n_llhttp__internal__n_req_http_start_2;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_29;
+-+          goto s_n_llhttp__internal__n_error_32;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9601,7 +9820,7 @@
+-           goto s_n_llhttp__internal__n_req_http_start_2;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_29;
+-+          goto s_n_llhttp__internal__n_error_32;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9655,7 +9874,7 @@
+-           goto s_n_llhttp__internal__n_span_end_llhttp__on_url_8;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_30;
+-+          goto s_n_llhttp__internal__n_error_33;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9712,7 +9931,7 @@
+-           goto s_n_llhttp__internal__n_span_end_stub_query_3;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_31;
+-+          goto s_n_llhttp__internal__n_error_34;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9742,7 +9961,7 @@
+-           goto s_n_llhttp__internal__n_url_query;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_32;
+-+          goto s_n_llhttp__internal__n_error_35;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9883,10 +10102,10 @@
+-         }
+-         case 7: {
+-           p++;
+--          goto s_n_llhttp__internal__n_error_33;
+-+          goto s_n_llhttp__internal__n_error_36;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_34;
+-+          goto s_n_llhttp__internal__n_error_37;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9941,7 +10160,7 @@
+-           goto s_n_llhttp__internal__n_url_server_with_at;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_35;
+-+          goto s_n_llhttp__internal__n_error_38;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9958,7 +10177,7 @@
+-           goto s_n_llhttp__internal__n_url_server;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_37;
+-+          goto s_n_llhttp__internal__n_error_40;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -9972,22 +10191,22 @@
+-       switch (*p) {
+-         case 10: {
+-           p++;
+--          goto s_n_llhttp__internal__n_error_36;
+-+          goto s_n_llhttp__internal__n_error_39;
+-         }
+-         case 13: {
+-           p++;
+--          goto s_n_llhttp__internal__n_error_36;
+-+          goto s_n_llhttp__internal__n_error_39;
+-         }
+-         case ' ': {
+-           p++;
+--          goto s_n_llhttp__internal__n_error_36;
+-+          goto s_n_llhttp__internal__n_error_39;
+-         }
+-         case '/': {
+-           p++;
+-           goto s_n_llhttp__internal__n_url_schema_delim_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_37;
+-+          goto s_n_llhttp__internal__n_error_40;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10029,7 +10248,7 @@
+-       switch (lookup_table[(uint8_t) *p]) {
+-         case 1: {
+-           p++;
+--          goto s_n_llhttp__internal__n_error_36;
+-+          goto s_n_llhttp__internal__n_error_39;
+-         }
+-         case 2: {
+-           goto s_n_llhttp__internal__n_span_end_stub_schema;
+-@@ -10039,7 +10258,7 @@
+-           goto s_n_llhttp__internal__n_url_schema;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_38;
+-+          goto s_n_llhttp__internal__n_error_41;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10071,7 +10290,7 @@
+-       switch (lookup_table[(uint8_t) *p]) {
+-         case 1: {
+-           p++;
+--          goto s_n_llhttp__internal__n_error_36;
+-+          goto s_n_llhttp__internal__n_error_39;
+-         }
+-         case 2: {
+-           goto s_n_llhttp__internal__n_span_start_stub_path_2;
+-@@ -10080,7 +10299,7 @@
+-           goto s_n_llhttp__internal__n_url_schema;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_39;
+-+          goto s_n_llhttp__internal__n_error_42;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10136,7 +10355,7 @@
+-           goto s_n_llhttp__internal__n_req_spaces_before_url;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_40;
+-+          goto s_n_llhttp__internal__n_error_43;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10161,7 +10380,7 @@
+-           return s_n_llhttp__internal__n_start_req_1;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10186,7 +10405,7 @@
+-           return s_n_llhttp__internal__n_start_req_2;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10211,7 +10430,7 @@
+-           return s_n_llhttp__internal__n_start_req_4;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10236,7 +10455,7 @@
+-           return s_n_llhttp__internal__n_start_req_6;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10254,7 +10473,7 @@
+-           goto s_n_llhttp__internal__n_invoke_store_method_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10275,7 +10494,7 @@
+-           goto s_n_llhttp__internal__n_start_req_7;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10296,7 +10515,7 @@
+-           goto s_n_llhttp__internal__n_start_req_5;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10321,7 +10540,7 @@
+-           return s_n_llhttp__internal__n_start_req_8;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10346,7 +10565,7 @@
+-           return s_n_llhttp__internal__n_start_req_9;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10371,7 +10590,7 @@
+-           return s_n_llhttp__internal__n_start_req_10;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10396,7 +10615,7 @@
+-           return s_n_llhttp__internal__n_start_req_12;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10421,7 +10640,7 @@
+-           return s_n_llhttp__internal__n_start_req_13;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10442,7 +10661,7 @@
+-           goto s_n_llhttp__internal__n_start_req_13;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10467,7 +10686,7 @@
+-           return s_n_llhttp__internal__n_start_req_15;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10492,7 +10711,7 @@
+-           return s_n_llhttp__internal__n_start_req_16;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10517,7 +10736,7 @@
+-           return s_n_llhttp__internal__n_start_req_18;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10542,7 +10761,7 @@
+-           return s_n_llhttp__internal__n_start_req_20;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10560,7 +10779,7 @@
+-           goto s_n_llhttp__internal__n_invoke_store_method_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10581,7 +10800,7 @@
+-           goto s_n_llhttp__internal__n_start_req_21;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10602,7 +10821,7 @@
+-           goto s_n_llhttp__internal__n_start_req_19;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10627,7 +10846,7 @@
+-           return s_n_llhttp__internal__n_start_req_22;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10656,7 +10875,7 @@
+-           goto s_n_llhttp__internal__n_start_req_22;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10681,7 +10900,7 @@
+-           return s_n_llhttp__internal__n_start_req_23;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10706,7 +10925,7 @@
+-           return s_n_llhttp__internal__n_start_req_24;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10731,7 +10950,7 @@
+-           return s_n_llhttp__internal__n_start_req_26;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10756,7 +10975,7 @@
+-           return s_n_llhttp__internal__n_start_req_27;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10781,7 +11000,7 @@
+-           return s_n_llhttp__internal__n_start_req_31;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10806,7 +11025,7 @@
+-           return s_n_llhttp__internal__n_start_req_32;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10827,7 +11046,7 @@
+-           goto s_n_llhttp__internal__n_start_req_32;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10844,7 +11063,7 @@
+-           goto s_n_llhttp__internal__n_start_req_30;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10866,7 +11085,7 @@
+-           goto s_n_llhttp__internal__n_start_req_29;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10891,7 +11110,7 @@
+-           return s_n_llhttp__internal__n_start_req_34;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10913,7 +11132,7 @@
+-           goto s_n_llhttp__internal__n_invoke_store_method_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10942,7 +11161,7 @@
+-           goto s_n_llhttp__internal__n_start_req_33;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10967,7 +11186,7 @@
+-           return s_n_llhttp__internal__n_start_req_37;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -10992,7 +11211,7 @@
+-           return s_n_llhttp__internal__n_start_req_38;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11013,7 +11232,7 @@
+-           goto s_n_llhttp__internal__n_start_req_38;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11030,7 +11249,7 @@
+-           goto s_n_llhttp__internal__n_start_req_36;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11055,7 +11274,7 @@
+-           return s_n_llhttp__internal__n_start_req_40;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11080,7 +11299,7 @@
+-           return s_n_llhttp__internal__n_start_req_41;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11105,7 +11324,7 @@
+-           return s_n_llhttp__internal__n_start_req_42;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11130,7 +11349,7 @@
+-           goto s_n_llhttp__internal__n_start_req_42;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11155,7 +11374,7 @@
+-           return s_n_llhttp__internal__n_start_req_43;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11180,7 +11399,7 @@
+-           return s_n_llhttp__internal__n_start_req_46;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11205,7 +11424,7 @@
+-           return s_n_llhttp__internal__n_start_req_48;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11230,7 +11449,7 @@
+-           return s_n_llhttp__internal__n_start_req_49;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11251,7 +11470,7 @@
+-           goto s_n_llhttp__internal__n_start_req_49;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11276,7 +11495,7 @@
+-           return s_n_llhttp__internal__n_start_req_50;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11301,7 +11520,7 @@
+-           goto s_n_llhttp__internal__n_start_req_50;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11318,7 +11537,7 @@
+-           goto s_n_llhttp__internal__n_start_req_45;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11391,7 +11610,7 @@
+-           goto s_n_llhttp__internal__n_start_req_44;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_48;
+-+          goto s_n_llhttp__internal__n_error_51;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11476,7 +11695,7 @@
+-           goto s_n_llhttp__internal__n_res_status_start;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_42;
+-+          goto s_n_llhttp__internal__n_error_45;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11556,7 +11775,7 @@
+-           goto s_n_llhttp__internal__n_invoke_update_status_code;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_43;
+-+          goto s_n_llhttp__internal__n_error_46;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11619,7 +11838,7 @@
+-           goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_44;
+-+          goto s_n_llhttp__internal__n_error_47;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11636,7 +11855,7 @@
+-           goto s_n_llhttp__internal__n_res_http_minor;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_45;
+-+          goto s_n_llhttp__internal__n_error_48;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11699,7 +11918,7 @@
+-           goto s_n_llhttp__internal__n_invoke_store_http_major_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_46;
+-+          goto s_n_llhttp__internal__n_error_49;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11723,7 +11942,7 @@
+-           return s_n_llhttp__internal__n_start_res;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_49;
+-+          goto s_n_llhttp__internal__n_error_52;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11748,7 +11967,7 @@
+-           return s_n_llhttp__internal__n_req_or_res_method_2;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_47;
+-+          goto s_n_llhttp__internal__n_error_50;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11772,7 +11991,7 @@
+-           return s_n_llhttp__internal__n_req_or_res_method_3;
+-         }
+-         case kMatchMismatch: {
+--          goto s_n_llhttp__internal__n_error_47;
+-+          goto s_n_llhttp__internal__n_error_50;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11793,7 +12012,7 @@
+-           goto s_n_llhttp__internal__n_req_or_res_method_3;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_47;
+-+          goto s_n_llhttp__internal__n_error_50;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11810,7 +12029,7 @@
+-           goto s_n_llhttp__internal__n_req_or_res_method_1;
+-         }
+-         default: {
+--          goto s_n_llhttp__internal__n_error_47;
+-+          goto s_n_llhttp__internal__n_error_50;
+-         }
+-       }
+-       /* UNREACHABLE */;
+-@@ -11870,7 +12089,7 @@
+-       /* UNREACHABLE */
+-       abort();
+-   }
+--  s_n_llhttp__internal__n_error_36: {
+-+  s_n_llhttp__internal__n_error_39: {
+-     state->error = 0x7;
+-     state->reason = "Invalid characters in url";
+-     state->error_pos = (const char*) p;
+-@@ -12314,7 +12533,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_16: {
+-+  s_n_llhttp__internal__n_error_17: {
+-     state->error = 0xb;
+-     state->reason = "Empty Content-Length";
+-     state->error_pos = (const char*) p;
+-@@ -12399,14 +12618,51 @@
+-   s_n_llhttp__internal__n_invoke_load_header_state: {
+-     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
+-       case 2:
+--        goto s_n_llhttp__internal__n_error_16;
+-+        goto s_n_llhttp__internal__n_error_17;
+-       default:
+-         goto s_n_llhttp__internal__n_invoke_load_header_state_1;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+-+  s_n_llhttp__internal__n_error_16: {
+-+    state->error = 0xa;
+-+    state->reason = "Invalid header value char";
+-+    state->error_pos = (const char*) p;
+-+    state->_current = (void*) (intptr_t) s_error;
+-+    return s_error;
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_test_flags_5: {
+-+    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+-+      case 1:
+-+        goto s_n_llhttp__internal__n_header_value_discard_lws;
+-+      default:
+-+        goto s_n_llhttp__internal__n_error_16;
+-+    }
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-   s_n_llhttp__internal__n_invoke_update_header_state_1: {
+-+    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
+-+      default:
+-+        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+-+    }
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_load_header_state_3: {
+-+    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
+-+      case 8:
+-+        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+-+      default:
+-+        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+-+    }
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_update_header_state_2: {
+-     switch (llhttp__internal__c_update_header_state(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_field_start;
+-@@ -12417,7 +12673,7 @@
+-   s_n_llhttp__internal__n_invoke_or_flags_7: {
+-     switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
+-       default:
+--        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+-+        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-@@ -12425,7 +12681,7 @@
+-   s_n_llhttp__internal__n_invoke_or_flags_8: {
+-     switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
+-       default:
+--        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+-+        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-@@ -12433,7 +12689,7 @@
+-   s_n_llhttp__internal__n_invoke_or_flags_9: {
+-     switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
+-       default:
+--        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+-+        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-@@ -12446,7 +12702,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_load_header_state_3: {
+-+  s_n_llhttp__internal__n_invoke_load_header_state_4: {
+-     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
+-       case 5:
+-         goto s_n_llhttp__internal__n_invoke_or_flags_7;
+-@@ -12462,7 +12718,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_17: {
+-+  s_n_llhttp__internal__n_error_18: {
+-     state->error = 0x3;
+-     state->reason = "Missing expected LF after header value";
+-     state->error_pos = (const char*) p;
+-@@ -12480,6 +12736,24 @@
+-     err = llhttp__on_header_value(state, start, p);
+-     if (err != 0) {
+-       state->error = err;
+-+      state->error_pos = (const char*) (p + 1);
+-+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
+-+      return s_error;
+-+    }
+-+    p++;
+-+    goto s_n_llhttp__internal__n_header_value_almost_done;
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3: {
+-+    const unsigned char* start;
+-+    int err;
+-+    
+-+    start = state->_span_pos0;
+-+    state->_span_pos0 = NULL;
+-+    err = llhttp__on_header_value(state, start, p);
+-+    if (err != 0) {
+-+      state->error = err;
+-       state->error_pos = (const char*) p;
+-       state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
+-       return s_error;
+-@@ -12488,7 +12762,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2: {
+-+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4: {
+-     const unsigned char* start;
+-     int err;
+-     
+-@@ -12506,7 +12780,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3: {
+-+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2: {
+-     const unsigned char* start;
+-     int err;
+-     
+-@@ -12515,35 +12789,25 @@
+-     err = llhttp__on_header_value(state, start, p);
+-     if (err != 0) {
+-       state->error = err;
+--      state->error_pos = (const char*) (p + 1);
+--      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
+-+      state->error_pos = (const char*) p;
+-+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_19;
+-       return s_error;
+-     }
+--    p++;
+--    goto s_n_llhttp__internal__n_header_value_almost_done;
+-+    goto s_n_llhttp__internal__n_error_19;
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_18: {
+--    state->error = 0xa;
+--    state->reason = "Invalid header value char";
+--    state->error_pos = (const char*) p;
+--    state->_current = (void*) (intptr_t) s_error;
+--    return s_error;
+--    /* UNREACHABLE */;
+--    abort();
+--  }
+--  s_n_llhttp__internal__n_invoke_test_flags_5: {
+-+  s_n_llhttp__internal__n_invoke_test_flags_6: {
+-     switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+-       case 1:
+-         goto s_n_llhttp__internal__n_header_value_lenient;
+-       default:
+--        goto s_n_llhttp__internal__n_error_18;
+-+        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_update_header_state_3: {
+-+  s_n_llhttp__internal__n_invoke_update_header_state_4: {
+-     switch (llhttp__internal__c_update_header_state(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_value_connection;
+-@@ -12554,7 +12818,7 @@
+-   s_n_llhttp__internal__n_invoke_or_flags_11: {
+-     switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
+-       default:
+--        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+-+        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-@@ -12562,7 +12826,7 @@
+-   s_n_llhttp__internal__n_invoke_or_flags_12: {
+-     switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
+-       default:
+--        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+-+        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-@@ -12570,7 +12834,7 @@
+-   s_n_llhttp__internal__n_invoke_or_flags_13: {
+-     switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
+-       default:
+--        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+-+        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-@@ -12583,7 +12847,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_load_header_state_4: {
+-+  s_n_llhttp__internal__n_invoke_load_header_state_5: {
+-     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
+-       case 5:
+-         goto s_n_llhttp__internal__n_invoke_or_flags_11;
+-@@ -12599,39 +12863,39 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_update_header_state_4: {
+--    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+-+  s_n_llhttp__internal__n_invoke_update_header_state_5: {
+-+    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_value_connection_token;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_update_header_state_2: {
+--    switch (llhttp__internal__c_update_header_state_2(state, p, endp)) {
+-+  s_n_llhttp__internal__n_invoke_update_header_state_3: {
+-+    switch (llhttp__internal__c_update_header_state_3(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_value_connection_ws;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_update_header_state_5: {
+--    switch (llhttp__internal__c_update_header_state_5(state, p, endp)) {
+-+  s_n_llhttp__internal__n_invoke_update_header_state_6: {
+-+    switch (llhttp__internal__c_update_header_state_6(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_value_connection_ws;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_update_header_state_6: {
+--    switch (llhttp__internal__c_update_header_state_6(state, p, endp)) {
+-+  s_n_llhttp__internal__n_invoke_update_header_state_7: {
+-+    switch (llhttp__internal__c_update_header_state_7(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_value_connection_ws;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4: {
+-+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5: {
+-     const unsigned char* start;
+-     int err;
+-     
+-@@ -12641,17 +12905,17 @@
+-     if (err != 0) {
+-       state->error = err;
+-       state->error_pos = (const char*) p;
+--      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_20;
+-+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_21;
+-       return s_error;
+-     }
+--    goto s_n_llhttp__internal__n_error_20;
+-+    goto s_n_llhttp__internal__n_error_21;
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+-   s_n_llhttp__internal__n_invoke_mul_add_content_length_1: {
+-     switch (llhttp__internal__c_mul_add_content_length_1(state, p, endp, match)) {
+-       case 1:
+--        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4;
+-+        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5;
+-       default:
+-         goto s_n_llhttp__internal__n_header_value_content_length;
+-     }
+-@@ -12666,7 +12930,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5: {
+-+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_6: {
+-     const unsigned char* start;
+-     int err;
+-     
+-@@ -12676,14 +12940,14 @@
+-     if (err != 0) {
+-       state->error = err;
+-       state->error_pos = (const char*) p;
+--      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_21;
+-+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_22;
+-       return s_error;
+-     }
+--    goto s_n_llhttp__internal__n_error_21;
+-+    goto s_n_llhttp__internal__n_error_22;
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_19: {
+-+  s_n_llhttp__internal__n_error_20: {
+-     state->error = 0x4;
+-     state->reason = "Duplicate Content-Length";
+-     state->error_pos = (const char*) p;
+-@@ -12692,26 +12956,82 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_test_flags_6: {
+--    switch (llhttp__internal__c_test_flags_6(state, p, endp)) {
+-+  s_n_llhttp__internal__n_invoke_test_flags_7: {
+-+    switch (llhttp__internal__c_test_flags_7(state, p, endp)) {
+-       case 0:
+-         goto s_n_llhttp__internal__n_header_value_content_length;
+-       default:
+--        goto s_n_llhttp__internal__n_error_19;
+-+        goto s_n_llhttp__internal__n_error_20;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_update_header_state_7: {
+--    switch (llhttp__internal__c_update_header_state_7(state, p, endp)) {
+-+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_8: {
+-+    const unsigned char* start;
+-+    int err;
+-+    
+-+    start = state->_span_pos0;
+-+    state->_span_pos0 = NULL;
+-+    err = llhttp__on_header_value(state, start, p);
+-+    if (err != 0) {
+-+      state->error = err;
+-+      state->error_pos = (const char*) (p + 1);
+-+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_24;
+-+      return s_error;
+-+    }
+-+    p++;
+-+    goto s_n_llhttp__internal__n_error_24;
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_update_header_state_8: {
+-+    switch (llhttp__internal__c_update_header_state_8(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_value_otherwise;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_update_header_state_8: {
+--    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+-+  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_7: {
+-+    const unsigned char* start;
+-+    int err;
+-+    
+-+    start = state->_span_pos0;
+-+    state->_span_pos0 = NULL;
+-+    err = llhttp__on_header_value(state, start, p);
+-+    if (err != 0) {
+-+      state->error = err;
+-+      state->error_pos = (const char*) (p + 1);
+-+      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_23;
+-+      return s_error;
+-+    }
+-+    p++;
+-+    goto s_n_llhttp__internal__n_error_23;
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_test_flags_9: {
+-+    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+-+      case 0:
+-+        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_7;
+-+      default:
+-+        goto s_n_llhttp__internal__n_header_value_te_chunked;
+-+    }
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_load_type_1: {
+-+    switch (llhttp__internal__c_load_type(state, p, endp)) {
+-+      case 1:
+-+        goto s_n_llhttp__internal__n_invoke_test_flags_9;
+-+      default:
+-+        goto s_n_llhttp__internal__n_header_value_te_chunked;
+-+    }
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_update_header_state_9: {
+-+    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_value;
+-     }
+-@@ -12726,6 +13046,34 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+-+  s_n_llhttp__internal__n_invoke_or_flags_17: {
+-+    switch (llhttp__internal__c_or_flags_16(state, p, endp)) {
+-+      default:
+-+        goto s_n_llhttp__internal__n_invoke_and_flags;
+-+    }
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_test_flags_10: {
+-+    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+-+      case 0:
+-+        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_8;
+-+      default:
+-+        goto s_n_llhttp__internal__n_invoke_or_flags_17;
+-+    }
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_load_type_2: {
+-+    switch (llhttp__internal__c_load_type(state, p, endp)) {
+-+      case 1:
+-+        goto s_n_llhttp__internal__n_invoke_test_flags_10;
+-+      default:
+-+        goto s_n_llhttp__internal__n_invoke_or_flags_17;
+-+    }
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-   s_n_llhttp__internal__n_invoke_or_flags_16: {
+-     switch (llhttp__internal__c_or_flags_16(state, p, endp)) {
+-       default:
+-@@ -12734,10 +13082,20 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_or_flags_17: {
+--    switch (llhttp__internal__c_or_flags_17(state, p, endp)) {
+-+  s_n_llhttp__internal__n_invoke_test_flags_8: {
+-+    switch (llhttp__internal__c_test_flags_8(state, p, endp)) {
+-+      case 1:
+-+        goto s_n_llhttp__internal__n_invoke_load_type_2;
+-       default:
+--        goto s_n_llhttp__internal__n_invoke_update_header_state_8;
+-+        goto s_n_llhttp__internal__n_invoke_or_flags_16;
+-+    }
+-+    /* UNREACHABLE */;
+-+    abort();
+-+  }
+-+  s_n_llhttp__internal__n_invoke_or_flags_18: {
+-+    switch (llhttp__internal__c_or_flags_18(state, p, endp)) {
+-+      default:
+-+        goto s_n_llhttp__internal__n_invoke_update_header_state_9;
+-     }
+-     /* UNREACHABLE */;
+-     abort();
+-@@ -12747,11 +13105,11 @@
+-       case 1:
+-         goto s_n_llhttp__internal__n_header_value_connection;
+-       case 2:
+--        goto s_n_llhttp__internal__n_invoke_test_flags_6;
+-+        goto s_n_llhttp__internal__n_invoke_test_flags_7;
+-       case 3:
+--        goto s_n_llhttp__internal__n_invoke_or_flags_16;
+-+        goto s_n_llhttp__internal__n_invoke_test_flags_8;
+-       case 4:
+--        goto s_n_llhttp__internal__n_invoke_or_flags_17;
+-+        goto s_n_llhttp__internal__n_invoke_or_flags_18;
+-       default:
+-         goto s_n_llhttp__internal__n_header_value;
+-     }
+-@@ -12794,7 +13152,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_22: {
+-+  s_n_llhttp__internal__n_error_25: {
+-     state->error = 0xa;
+-     state->reason = "Invalid header token";
+-     state->error_pos = (const char*) p;
+-@@ -12803,8 +13161,8 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_update_header_state_9: {
+--    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+-+  s_n_llhttp__internal__n_invoke_update_header_state_10: {
+-+    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_field_general;
+-     }
+-@@ -12819,8 +13177,8 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_invoke_update_header_state_10: {
+--    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+-+  s_n_llhttp__internal__n_invoke_update_header_state_11: {
+-+    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
+-       default:
+-         goto s_n_llhttp__internal__n_header_field_general;
+-     }
+-@@ -12860,7 +13218,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_23: {
+-+  s_n_llhttp__internal__n_error_26: {
+-     state->error = 0x7;
+-     state->reason = "Expected CRLF";
+-     state->error_pos = (const char*) p;
+-@@ -12886,7 +13244,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_24: {
+-+  s_n_llhttp__internal__n_error_27: {
+-     state->error = 0x9;
+-     state->reason = "Expected CRLF after version";
+-     state->error_pos = (const char*) p;
+-@@ -12903,7 +13261,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_25: {
+-+  s_n_llhttp__internal__n_error_28: {
+-     state->error = 0x9;
+-     state->reason = "Invalid minor version";
+-     state->error_pos = (const char*) p;
+-@@ -12912,7 +13270,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_26: {
+-+  s_n_llhttp__internal__n_error_29: {
+-     state->error = 0x9;
+-     state->reason = "Expected dot";
+-     state->error_pos = (const char*) p;
+-@@ -12929,7 +13287,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_27: {
+-+  s_n_llhttp__internal__n_error_30: {
+-     state->error = 0x9;
+-     state->reason = "Invalid major version";
+-     state->error_pos = (const char*) p;
+-@@ -12938,7 +13296,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_29: {
+-+  s_n_llhttp__internal__n_error_32: {
+-     state->error = 0x8;
+-     state->reason = "Expected HTTP/";
+-     state->error_pos = (const char*) p;
+-@@ -12947,7 +13305,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_28: {
+-+  s_n_llhttp__internal__n_error_31: {
+-     state->error = 0x8;
+-     state->reason = "Expected SOURCE method for ICE/x.x request";
+-     state->error_pos = (const char*) p;
+-@@ -12959,7 +13317,7 @@
+-   s_n_llhttp__internal__n_invoke_is_equal_method_1: {
+-     switch (llhttp__internal__c_is_equal_method_1(state, p, endp)) {
+-       case 0:
+--        goto s_n_llhttp__internal__n_error_28;
+-+        goto s_n_llhttp__internal__n_error_31;
+-       default:
+-         goto s_n_llhttp__internal__n_req_http_major;
+-     }
+-@@ -13034,7 +13392,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_30: {
+-+  s_n_llhttp__internal__n_error_33: {
+-     state->error = 0x7;
+-     state->reason = "Invalid char in url fragment start";
+-     state->error_pos = (const char*) p;
+-@@ -13094,7 +13452,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_31: {
+-+  s_n_llhttp__internal__n_error_34: {
+-     state->error = 0x7;
+-     state->reason = "Invalid char in url query";
+-     state->error_pos = (const char*) p;
+-@@ -13103,7 +13461,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_32: {
+-+  s_n_llhttp__internal__n_error_35: {
+-     state->error = 0x7;
+-     state->reason = "Invalid char in url path";
+-     state->error_pos = (const char*) p;
+-@@ -13214,7 +13572,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_33: {
+-+  s_n_llhttp__internal__n_error_36: {
+-     state->error = 0x7;
+-     state->reason = "Double @ in url";
+-     state->error_pos = (const char*) p;
+-@@ -13223,7 +13581,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_34: {
+-+  s_n_llhttp__internal__n_error_37: {
+-     state->error = 0x7;
+-     state->reason = "Unexpected char in url server";
+-     state->error_pos = (const char*) p;
+-@@ -13232,7 +13590,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_35: {
+-+  s_n_llhttp__internal__n_error_38: {
+-     state->error = 0x7;
+-     state->reason = "Unexpected char in url server";
+-     state->error_pos = (const char*) p;
+-@@ -13241,7 +13599,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_37: {
+-+  s_n_llhttp__internal__n_error_40: {
+-     state->error = 0x7;
+-     state->reason = "Unexpected char in url schema";
+-     state->error_pos = (const char*) p;
+-@@ -13250,7 +13608,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_38: {
+-+  s_n_llhttp__internal__n_error_41: {
+-     state->error = 0x7;
+-     state->reason = "Unexpected char in url schema";
+-     state->error_pos = (const char*) p;
+-@@ -13259,7 +13617,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_39: {
+-+  s_n_llhttp__internal__n_error_42: {
+-     state->error = 0x7;
+-     state->reason = "Unexpected start char in url";
+-     state->error_pos = (const char*) p;
+-@@ -13278,7 +13636,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_40: {
+-+  s_n_llhttp__internal__n_error_43: {
+-     state->error = 0x6;
+-     state->reason = "Expected space after method";
+-     state->error_pos = (const char*) p;
+-@@ -13295,7 +13653,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_48: {
+-+  s_n_llhttp__internal__n_error_51: {
+-     state->error = 0x6;
+-     state->reason = "Invalid method encountered";
+-     state->error_pos = (const char*) p;
+-@@ -13304,7 +13662,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_41: {
+-+  s_n_llhttp__internal__n_error_44: {
+-     state->error = 0xd;
+-     state->reason = "Response overflow";
+-     state->error_pos = (const char*) p;
+-@@ -13316,7 +13674,7 @@
+-   s_n_llhttp__internal__n_invoke_mul_add_status_code: {
+-     switch (llhttp__internal__c_mul_add_status_code(state, p, endp, match)) {
+-       case 1:
+--        goto s_n_llhttp__internal__n_error_41;
+-+        goto s_n_llhttp__internal__n_error_44;
+-       default:
+-         goto s_n_llhttp__internal__n_res_status_code;
+-     }
+-@@ -13359,7 +13717,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_42: {
+-+  s_n_llhttp__internal__n_error_45: {
+-     state->error = 0xd;
+-     state->reason = "Invalid response status";
+-     state->error_pos = (const char*) p;
+-@@ -13376,7 +13734,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_43: {
+-+  s_n_llhttp__internal__n_error_46: {
+-     state->error = 0x9;
+-     state->reason = "Expected space after version";
+-     state->error_pos = (const char*) p;
+-@@ -13393,7 +13751,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_44: {
+-+  s_n_llhttp__internal__n_error_47: {
+-     state->error = 0x9;
+-     state->reason = "Invalid minor version";
+-     state->error_pos = (const char*) p;
+-@@ -13402,7 +13760,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_45: {
+-+  s_n_llhttp__internal__n_error_48: {
+-     state->error = 0x9;
+-     state->reason = "Expected dot";
+-     state->error_pos = (const char*) p;
+-@@ -13419,7 +13777,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_46: {
+-+  s_n_llhttp__internal__n_error_49: {
+-     state->error = 0x9;
+-     state->reason = "Invalid major version";
+-     state->error_pos = (const char*) p;
+-@@ -13428,7 +13786,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_49: {
+-+  s_n_llhttp__internal__n_error_52: {
+-     state->error = 0x8;
+-     state->reason = "Expected HTTP/";
+-     state->error_pos = (const char*) p;
+-@@ -13453,7 +13811,7 @@
+-     /* UNREACHABLE */;
+-     abort();
+-   }
+--  s_n_llhttp__internal__n_error_47: {
+-+  s_n_llhttp__internal__n_error_50: {
+-     state->error = 0x8;
+-     state->reason = "Invalid word encountered";
+-     state->error_pos = (const char*) p;
+---- nodejs-12.22.12~dfsg/test/parallel/test-http-invalid-te.js
+-+++ nodejs-12.22.12~dfsg/test/parallel/test-http-invalid-te.js
+-@@ -13,7 +13,7 @@ Content-Type: text/plain; charset=utf-8
+- Host: hacker.exploit.com
+- Connection: keep-alive
+- Content-Length: 10
+--Transfer-Encoding: chunked, eee
+-+Transfer-Encoding: eee, chunked
+- 
+- HELLOWORLDPOST / HTTP/1.1
+- Content-Type: text/plain; charset=utf-8
+---- nodejs-12.22.12~dfsg/test/parallel/test-http-missing-header-separator-cr.js
+-+++ nodejs-12.22.12~dfsg/test/parallel/test-http-missing-header-separator-cr.js
+-@@ -0,0 +1,83 @@
+-+'use strict';
+-+
+-+const common = require('../common');
+-+const assert = require('assert');
+-+
+-+const http = require('http');
+-+const net = require('net');
+-+
+-+function serverHandler(server, msg) {
+-+  const client = net.connect(server.address().port, 'localhost');
+-+
+-+  let response = '';
+-+
+-+  client.on('data', common.mustCall((chunk) => {
+-+    response += chunk.toString('utf-8');
+-+  }));
+-+
+-+  client.setEncoding('utf8');
+-+  client.on('error', common.mustNotCall());
+-+  client.on('end', common.mustCall(() => {
+-+    assert.strictEqual(
+-+      response,
+-+      'HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n'
+-+    );
+-+    server.close();
+-+  }));
+-+  client.write(msg);
+-+  client.resume();
+-+}
+-+
+-+{
+-+  const msg = [
+-+    'GET / HTTP/1.1',
+-+    'Host: localhost',
+-+    'Dummy: x\nContent-Length: 23',
+-+    '',
+-+    'GET / HTTP/1.1',
+-+    'Dummy: GET /admin HTTP/1.1',
+-+    'Host: localhost',
+-+    '',
+-+    '',
+-+  ].join('\r\n');
+-+
+-+  const server = http.createServer(common.mustNotCall());
+-+
+-+  server.listen(0, common.mustCall(serverHandler.bind(null, server, msg)));
+-+}
+-+
+-+{
+-+  const msg = [
+-+    'POST / HTTP/1.1',
+-+    'Host: localhost',
+-+    'x:x\nTransfer-Encoding: chunked',
+-+    '',
+-+    '1',
+-+    'A',
+-+    '0',
+-+    '',
+-+    '',
+-+  ].join('\r\n');
+-+
+-+  const server = http.createServer(common.mustNotCall());
+-+
+-+  server.listen(0, common.mustCall(serverHandler.bind(null, server, msg)));
+-+}
+-+
+-+{
+-+  const msg = [
+-+    'POST / HTTP/1.1',
+-+    'Host: localhost',
+-+    'x:\nTransfer-Encoding: chunked',
+-+    '',
+-+    '1',
+-+    'A',
+-+    '0',
+-+    '',
+-+    '',
+-+  ].join('\r\n');
+-+
+-+  const server = http.createServer(common.mustNotCall());
+-+
+-+  server.listen(0, common.mustCall(serverHandler.bind(null, server, msg)));
+-+}
+---- /dev/null
+-+++ nodejs-12.22.12~dfsg/test/parallel/test-http-transfer-encoding-repeated-chunked.js
+-@@ -0,0 +1,51 @@
+-+'use strict';
+-+
+-+const common = require('../common');
+-+const assert = require('assert');
+-+
+-+const http = require('http');
+-+const net = require('net');
+-+
+-+const msg = [
+-+  'POST / HTTP/1.1',
+-+  'Host: 127.0.0.1',
+-+  'Transfer-Encoding: chunkedchunked',
+-+  '',
+-+  '1',
+-+  'A',
+-+  '0',
+-+  '',
+-+].join('\r\n');
+-+
+-+const server = http.createServer(common.mustCall((req, res) => {
+-+  // Verify that no data is received
+-+
+-+  req.on('data', common.mustNotCall());
+-+
+-+  req.on('end', common.mustNotCall(() => {
+-+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+-+    res.end();
+-+  }));
+-+}, 1));
+-+
+-+server.listen(0, common.mustCall(() => {
+-+  const client = net.connect(server.address().port, 'localhost');
+-+
+-+  let response = '';
+-+
+-+  client.on('data', common.mustCall((chunk) => {
+-+    response += chunk.toString('utf-8');
+-+  }));
+-+
+-+  client.setEncoding('utf8');
+-+  client.on('error', common.mustNotCall());
+-+  client.on('end', common.mustCall(() => {
+-+    assert.strictEqual(
+-+      response,
+-+      'HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n'
+-+    );
+-+    server.close();
+-+  }));
+-+  client.write(msg);
+-+  client.resume();
+-+}));
+---- nodejs-12.22.12~dfsg/test/parallel/test-http-transfer-encoding-smuggling.js
+-+++ nodejs-12.22.12~dfsg/test/parallel/test-http-transfer-encoding-smuggling.js
+-@@ -1,46 +1,89 @@
+- 'use strict';
+- 
+- const common = require('../common');
+--
+- const assert = require('assert');
+-+
+- const http = require('http');
+- const net = require('net');
+- 
+--const msg = [
+--  'POST / HTTP/1.1',
+--  'Host: 127.0.0.1',
+--  'Transfer-Encoding: chunked',
+--  'Transfer-Encoding: chunked-false',
+--  'Connection: upgrade',
+--  '',
+--  '1',
+--  'A',
+--  '0',
+--  '',
+--  'GET /flag HTTP/1.1',
+--  'Host: 127.0.0.1',
+--  '',
+--  '',
+--].join('\r\n');
+--
+--// Verify that the server is called only once even with a smuggled request.
+--
+--const server = http.createServer(common.mustCall((req, res) => {
+--  res.end();
+--}, 1));
+--
+--function send(next) {
+--  const client = net.connect(server.address().port, 'localhost');
+--  client.setEncoding('utf8');
+--  client.on('error', common.mustNotCall());
+--  client.on('end', next);
+--  client.write(msg);
+--  client.resume();
+-+{
+-+  const msg = [
+-+    'POST / HTTP/1.1',
+-+    'Host: 127.0.0.1',
+-+    'Transfer-Encoding: chunked',
+-+    'Transfer-Encoding: chunked-false',
+-+    'Connection: upgrade',
+-+    '',
+-+    '1',
+-+    'A',
+-+    '0',
+-+    '',
+-+    'GET /flag HTTP/1.1',
+-+    'Host: 127.0.0.1',
+-+    '',
+-+    '',
+-+  ].join('\r\n');
+-+
+-+  const server = http.createServer(common.mustNotCall((req, res) => {
+-+    res.end();
+-+  }, 1));
+-+
+-+  server.listen(0, common.mustCall(() => {
+-+    const client = net.connect(server.address().port, 'localhost');
+-+
+-+    let response = '';
+-+
+-+    // Verify that the server listener is never called
+-+
+-+    client.on('data', common.mustCall((chunk) => {
+-+      response += chunk.toString('utf-8');
+-+    }));
+-+
+-+    client.setEncoding('utf8');
+-+    client.on('error', common.mustNotCall());
+-+    client.on('end', common.mustCall(() => {
+-+      assert.strictEqual(
+-+        response,
+-+        'HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n'
+-+      );
+-+      server.close();
+-+    }));
+-+    client.write(msg);
+-+    client.resume();
+-+  }));
+- }
+- 
+--server.listen(0, common.mustCall((err) => {
+--  assert.ifError(err);
+--  send(common.mustCall(() => {
+--    server.close();
+-+{
+-+  const msg = [
+-+    'POST / HTTP/1.1',
+-+    'Host: 127.0.0.1',
+-+    'Transfer-Encoding: chunked',
+-+    ' , chunked-false',
+-+    'Connection: upgrade',
+-+    '',
+-+    '1',
+-+    'A',
+-+    '0',
+-+    '',
+-+    'GET /flag HTTP/1.1',
+-+    'Host: 127.0.0.1',
+-+    '',
+-+    '',
+-+  ].join('\r\n');
+-+
+-+  const server = http.createServer(common.mustCall((request, response) => {
+-+    assert.notStrictEqual(request.url, '/admin');
+-+    response.end('hello world');
+-+  }), 1);
+-+
+-+  server.listen(0, common.mustCall(() => {
+-+    const client = net.connect(server.address().port, 'localhost');
+-+
+-+    client.on('end', common.mustCall(function() {
+-+      server.close();
+-+    }));
+-+
+-+    client.write(msg);
+-+    client.resume();
+-   }));
+--}));
+-+}
+---- nodejs-12.22.12~dfsg/test/parallel/test-http-header-overflow.js
+-+++ nodejs-12.22.12~dfsg/test/parallel/test-http-header-overflow.js
+-@@ -1,3 +1,5 @@
+-+// Flags: --expose-internals
+-+
+- 'use strict';
+- const { expectsError, mustCall } = require('../common');
+- const assert = require('assert');
+-@@ -8,7 +10,7 @@ const CRLF = '\r\n';
+- const DUMMY_HEADER_NAME = 'Cookie: ';
+- const DUMMY_HEADER_VALUE = 'a'.repeat(
+-   // Plus one is to make it 1 byte too big
+--  maxHeaderSize - DUMMY_HEADER_NAME.length - (2 * CRLF.length) + 1
+-+  maxHeaderSize - DUMMY_HEADER_NAME.length + 2
+- );
+- const PAYLOAD_GET = 'GET /blah HTTP/1.1';
+- const PAYLOAD = PAYLOAD_GET + CRLF +
+-@@ -21,7 +23,7 @@ server.on('connection', mustCall((socket
+-     name: 'Error',
+-     message: 'Parse Error: Header overflow',
+-     code: 'HPE_HEADER_OVERFLOW',
+--    bytesParsed: maxHeaderSize + PAYLOAD_GET.length,
+-+    bytesParsed: maxHeaderSize + PAYLOAD_GET.length + (CRLF.length * 2) + 1,
+-     rawPacket: Buffer.from(PAYLOAD)
+-   }));
+- }));
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/gcc13.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/gcc13.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/gcc13.patch	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/gcc13.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,63 +0,0 @@
+-From 576aed71db7b40c90b44c623580629792a606928 Mon Sep 17 00:00:00 2001
+-From: Jiawen Geng <technicalcute@gmail.com>
+-Date: Fri, 14 Oct 2022 09:54:33 +0800
+-Subject: [PATCH] deps: V8: cherry-pick c2792e58035f
+-MIME-Version: 1.0
+-Content-Type: text/plain; charset=UTF-8
+-Content-Transfer-Encoding: 8bit
+-
+-Original commit message:
+-
+-    [base] Fix build with gcc-13
+-
+-    See https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes.
+-
+-    Also see Gentoo Linux bug report: https://bugs.gentoo.org/865981
+-
+-    Change-Id: I421f396b02ba37e12ee70048ee33e034f8113566
+-    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3934140
+-    Reviewed-by: Clemens Backes <clemensb@chromium.org>
+-    Reviewed-by: Simon Zund <szuend@chromium.org>
+-    Commit-Queue: Clemens Backes <clemensb@chromium.org>
+-    Cr-Commit-Position: refs/heads/main@{#83587}
+-
+-Refs: https://github.com/v8/v8/commit/c2792e58035fcbaa16d0cb70998852fbeb5df4cc
+-PR-URL: https://github.com/nodejs/node/pull/44961
+-Fixes: https://github.com/nodejs/node/issues/43642
+-Reviewed-By: Michael Zasso <targos@protonmail.com>
+-Reviewed-By: Richard Lau <rlau@redhat.com>
+-Reviewed-By: Luigi Pinca <luigipinca@gmail.com>
+-Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
+-
+-Upstream-Status: Backport [https://github.com/nodejs/node/commit/0be1c5728173ea9ac42843058e26b6268568acf0]
+-Signed-off-by: Khem Raj <raj.khem@gmail.com>
+----
+- deps/v8/AUTHORS                               | 1 +
+- deps/v8/src/base/logging.h                    | 1 +
+- deps/v8/src/inspector/v8-string-conversions.h | 1 +
+- 3 files changed, 3 insertions(+)
+-
+-diff --git a/deps/v8/src/base/logging.h b/deps/v8/src/base/logging.h
+-index 08db24a9..38be165f 100644
+---- a/deps/v8/src/base/logging.h
+-+++ b/deps/v8/src/base/logging.h
+-@@ -5,6 +5,7 @@
+- #ifndef V8_BASE_LOGGING_H_
+- #define V8_BASE_LOGGING_H_
+- 
+-+#include <cstdint>
+- #include <cstring>
+- #include <sstream>
+- #include <string>
+-diff --git a/deps/v8/src/inspector/v8-string-conversions.h b/deps/v8/src/inspector/v8-string-conversions.h
+-index c1d69c18..eb33c681 100644
+---- a/deps/v8/src/inspector/v8-string-conversions.h
+-+++ b/deps/v8/src/inspector/v8-string-conversions.h
+-@@ -5,6 +5,7 @@
+- #ifndef V8_INSPECTOR_V8_STRING_CONVERSIONS_H_
+- #define V8_INSPECTOR_V8_STRING_CONVERSIONS_H_
+- 
+-+#include <cstdint>
+- #include <string>
+- 
+- // Conversion routines between UT8 and UTF16, used by string-16.{h,cc}. You may
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/libatomic-nodejs14.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/libatomic-nodejs14.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/libatomic-nodejs14.patch	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/libatomic-nodejs14.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,21 +0,0 @@
+-Link mksnapshot with libatomic on x86
+-
+-Clang-12 on x86 emits atomic builtins
+-
+-Fixes
+-| module-compiler.cc:(.text._ZN2v88internal4wasm12_GLOBAL__N_123ExecuteCompilationUnitsERKSt10shared_ptrINS2_22BackgroundCompileTokenEEPNS0_8CountersEiNS2_19CompileBaselineOnlyE+0x558): un
+-defined reference to `__atomic_load'
+-
+-Upstream-Status: Pending
+-Signed-off-by: Khem Raj <raj.khem@gmail.com>
+-
+---- a/tools/v8_gypfiles/v8.gyp
+-+++ b/tools/v8_gypfiles/v8.gyp
+-@@ -1336,6 +1336,7 @@
+-     {
+-       'target_name': 'mksnapshot',
+-       'type': 'executable',
+-+      'libraries': [ '-latomic' ],
+-       'dependencies': [
+-         'v8_base_without_compiler',
+-         'v8_compiler_for_mksnapshot',
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/libatomic.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/libatomic.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/libatomic.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/libatomic.patch	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,21 @@
++Link mksnapshot with libatomic on x86
++
++Clang-12 on x86 emits atomic builtins
++
++Fixes
++| module-compiler.cc:(.text._ZN2v88internal4wasm12_GLOBAL__N_123ExecuteCompilationUnitsERKSt10shared_ptrINS2_22BackgroundCompileTokenEEPNS0_8CountersEiNS2_19CompileBaselineOnlyE+0x558): un
++defined reference to `__atomic_load'
++
++Upstream-Status: Pending
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++
++--- a/tools/v8_gypfiles/v8.gyp
+++++ b/tools/v8_gypfiles/v8.gyp
++@@ -1436,6 +1436,7 @@
++     {
++       'target_name': 'mksnapshot',
++       'type': 'executable',
+++      'libraries': [ '-latomic' ],
++       'dependencies': [
++         'v8_base_without_compiler',
++         'v8_compiler_for_mksnapshot',
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/mips-less-memory-nodejs14.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/mips-less-memory-nodejs14.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/mips-less-memory-nodejs14.patch	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/mips-less-memory-nodejs14.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,32 +0,0 @@
+-Description: mksnapshot uses too much memory on 32-bit mipsel
+-Author: Jérémy Lal <kapouer@melix.org>
+-Last-Update: 2020-06-03
+-Forwarded: https://bugs.chromium.org/p/v8/issues/detail?id=10586
+-
+-This ensures that we reserve 500M instead of 2G range for codegen
+-ensures that qemu-mips can allocate such large ranges
+-
+-Signed-off-by: Khem Raj <raj.khem@gmail.com>
+-
+---- a/deps/v8/src/common/globals.h
+-+++ b/deps/v8/src/common/globals.h
+-@@ -224,7 +224,7 @@ constexpr size_t kMinimumCodeRangeSize =
+- constexpr size_t kMinExpectedOSPageSize = 64 * KB;  // OS page on PPC Linux
+- #elif V8_TARGET_ARCH_MIPS
+- constexpr bool kPlatformRequiresCodeRange = false;
+--constexpr size_t kMaximalCodeRangeSize = 2048LL * MB;
+-+constexpr size_t kMaximalCodeRangeSize = 512 * MB;
+- constexpr size_t kMinimumCodeRangeSize = 0 * MB;
+- constexpr size_t kMinExpectedOSPageSize = 4 * KB;  // OS page.
+- #else
+---- a/deps/v8/src/codegen/mips/constants-mips.h
+-+++ b/deps/v8/src/codegen/mips/constants-mips.h
+-@@ -140,7 +140,7 @@ const uint32_t kLeastSignificantByteInIn
+- namespace v8 {
+- namespace internal {
+-
+--constexpr size_t kMaxPCRelativeCodeRangeInMB = 4096;
+-+constexpr size_t kMaxPCRelativeCodeRangeInMB = 1024;
+-
+- // -----------------------------------------------------------------------------
+- // Registers and FPURegisters.
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/mips-less-memory.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/mips-less-memory.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/mips-less-memory.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/mips-less-memory.patch	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,37 @@
++Description: mksnapshot uses too much memory on 32-bit mipsel
++Author: Jérémy Lal <kapouer@melix.org>
++Last-Update: 2020-06-03
++Forwarded: https://bugs.chromium.org/p/v8/issues/detail?id=10586
++
++This ensures that we reserve 500M instead of 2G range for codegen
++ensures that qemu-mips can allocate such large ranges
++
++Upstream-Status: Inappropriate [embedded specific]
++
++Imported from debian https://salsa.debian.org/js-team/nodejs/-/blob/master-12.x/debian/patches/mips-less-memory.patch
++https://buildd.debian.org/status/fetch.php?pkg=nodejs&arch=mipsel&ver=12.17.0~dfsg-2&stamp=1591050388&raw=0
++
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++
++--- a/deps/v8/src/common/globals.h
+++++ b/deps/v8/src/common/globals.h
++@@ -224,7 +224,7 @@ constexpr size_t kMinimumCodeRangeSize =
++ constexpr size_t kMinExpectedOSPageSize = 64 * KB;  // OS page on PPC Linux
++ #elif V8_TARGET_ARCH_MIPS
++ constexpr bool kPlatformRequiresCodeRange = false;
++-constexpr size_t kMaximalCodeRangeSize = 2048LL * MB;
+++constexpr size_t kMaximalCodeRangeSize = 512 * MB;
++ constexpr size_t kMinimumCodeRangeSize = 0 * MB;
++ constexpr size_t kMinExpectedOSPageSize = 4 * KB;  // OS page.
++ #else
++--- a/deps/v8/src/codegen/mips/constants-mips.h
+++++ b/deps/v8/src/codegen/mips/constants-mips.h
++@@ -140,7 +140,7 @@ const uint32_t kLeastSignificantByteInIn
++ namespace v8 {
++ namespace internal {
++ 
++-constexpr size_t kMaxPCRelativeCodeRangeInMB = 4096;
+++constexpr size_t kMaxPCRelativeCodeRangeInMB = 1024;
++ 
++ // -----------------------------------------------------------------------------
++ // Registers and FPURegisters.
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/mips-warnings.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/mips-warnings.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/mips-warnings.patch	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/mips-warnings.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,19 +0,0 @@
+-Add explicit static cast to fix narrowing warning
+-
+-Fixes
+-deps/v8/src/codegen/mips/assembler-mips.cc:3556:44: error: non-constant-expression cannot be narrowed from type 'int' to 'size_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
+-
+-Upstream-Status: Pending
+-
+-Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---- a/deps/v8/src/codegen/mips/assembler-mips.cc
+-+++ b/deps/v8/src/codegen/mips/assembler-mips.cc
+-@@ -3553,7 +3553,7 @@ void Assembler::GrowBuffer() {
+-                                reloc_info_writer.last_pc() + pc_delta);
+- 
+-   // Relocate runtime entries.
+--  Vector<byte> instructions{buffer_start_, pc_offset()};
+-+  Vector<byte> instructions{buffer_start_, static_cast<size_t>(pc_offset())};
+-   Vector<const byte> reloc_info{reloc_info_writer.pos(), reloc_size};
+-   for (RelocIterator it(instructions, reloc_info, 0); !it.done(); it.next()) {
+-     RelocInfo::Mode rmode = it.rinfo()->rmode();
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/python-3.11-invalid-mode-rU.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/python-3.11-invalid-mode-rU.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/python-3.11-invalid-mode-rU.patch	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/python-3.11-invalid-mode-rU.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,46 +0,0 @@
+-From e4d6f2e4091a4c7b6f3281be0e281b32ee6e5a33 Mon Sep 17 00:00:00 2001
+-From: Christian Clauss <cclauss@me.com>
+-Date: Thu, 26 Nov 2020 12:39:11 +0100
+-Subject: [PATCH] Fix ValueError: invalid mode: 'rU' while trying to load
+- binding.gyp
+-
+-Fixes nodejs/node-gyp#2219
+-File mode `U` is deprecated in Python 3 https://docs.python.org/3/library/functions.html#open
+-https://github.com/asottile/pyupgrade#redundant-open-modes
+-
+-Upstream-Status: Backport [https://github.com/nodejs/gyp-next/commit/3f8cb33ea4d191df41f4fb7a1dfbd302507f7260]
+-Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+----
+- deps/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py | 2 +-
+- tools/gyp/pylib/gyp/input.py                          | 2 +-
+- 2 files changed, 2 insertions(+), 2 deletions(-)
+-
+-diff --git a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py
+-index d174280..2f34bc0 100644
+---- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py
+-+++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py
+-@@ -226,7 +226,7 @@ def LoadOneBuildFile(build_file_path, data, aux_data, includes,
+-     # Open the build file for read ('r') with universal-newlines mode ('U')
+-     # to make sure platform specific newlines ('\r\n' or '\r') are converted to '\n'
+-     # which otherwise will fail eval()
+--    if sys.platform == 'zos':
+-+    if PY3 or sys.platform == 'zos':
+-       # On z/OS, universal-newlines mode treats the file as an ascii file. But since
+-       # node-gyp produces ebcdic files, do not use that mode.
+-       build_file_contents = open(build_file_path, 'r').read()
+-diff --git a/tools/gyp/pylib/gyp/input.py b/tools/gyp/pylib/gyp/input.py
+-index 1f40abb..fd12e78 100644
+---- a/tools/gyp/pylib/gyp/input.py
+-+++ b/tools/gyp/pylib/gyp/input.py
+-@@ -226,7 +226,7 @@ def LoadOneBuildFile(build_file_path, data, aux_data, includes,
+-     # Open the build file for read ('r') with universal-newlines mode ('U')
+-     # to make sure platform specific newlines ('\r\n' or '\r') are converted to '\n'
+-     # which otherwise will fail eval()
+--    if sys.platform == 'zos':
+-+    if PY3 or sys.platform == 'zos':
+-       # On z/OS, universal-newlines mode treats the file as an ascii file. But since
+-       # node-gyp produces ebcdic files, do not use that mode.
+-       build_file_contents = open(build_file_path, 'r').read()
+--- 
+-2.38.1
+-
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/run-ptest b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/run-ptest
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/run-ptest	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/run-ptest	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,3 @@
++#!/bin/sh
++
++./cctest
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/system-c-ares.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/system-c-ares.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/system-c-ares.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs/system-c-ares.patch	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,24 @@
++keep nodejs compatible with c-ares 1.17.1
++
++Upstream-Status: Inappropriate [c-ares specific]
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++
++--- a/src/cares_wrap.h
+++++ b/src/cares_wrap.h
++@@ -22,7 +22,15 @@
++ # include <netdb.h>
++ #endif  // __POSIX__
++ 
++-# include <ares_nameser.h>
+++#if defined(__ANDROID__) || \
+++    defined(__MINGW32__) || \
+++    defined(__OpenBSD__) || \
+++    defined(_MSC_VER)
+++
+++# include <nameser.h>
+++#else
+++# include <arpa/nameser.h>
+++#endif
++ 
++ namespace node {
++ namespace cares_wrap {
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs_12.22.12.bb b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs_12.22.12.bb
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs_12.22.12.bb	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs_12.22.12.bb	1970-01-01 01:00:00.000000000 +0100
+@@ -1,167 +0,0 @@
+-DESCRIPTION = "nodeJS Evented I/O for V8 JavaScript"
+-HOMEPAGE = "http://nodejs.org"
+-LICENSE = "MIT & BSD & Artistic-2.0"
+-LIC_FILES_CHKSUM = "file://LICENSE;md5=93997aa7a45ba0f25f9c61aaab153ab8"
+-
+-DEPENDS = "openssl"
+-DEPENDS_append_class-target = " nodejs-native"
+-
+-inherit pkgconfig python3native
+-
+-COMPATIBLE_MACHINE_armv4 = "(!.*armv4).*"
+-COMPATIBLE_MACHINE_armv5 = "(!.*armv5).*"
+-COMPATIBLE_MACHINE_mips64 = "(!.*mips64).*"
+-
+-COMPATIBLE_HOST_riscv64 = "null"
+-COMPATIBLE_HOST_riscv32 = "null"
+-
+-SRC_URI = "http://nodejs.org/dist/v${PV}/node-v${PV}.tar.xz \
+-           file://0001-Disable-running-gyp-files-for-bundled-deps.patch \
+-           file://0003-Install-both-binaries-and-use-libdir.patch \
+-           file://0004-v8-don-t-override-ARM-CFLAGS.patch \
+-           file://big-endian.patch \
+-           file://mips-warnings.patch \
+-           file://0001-Remove-use-of-register-r7-because-llvm-now-issues-an.patch \
+-           file://CVE-2022-32212.patch \
+-           file://CVE-2022-35255.patch \
+-           file://CVE-2022-43548.patch \
+-           file://CVE-llhttp.patch \
+-           file://python-3.11-invalid-mode-rU.patch \
+-           file://gcc13.patch \
+-           "
+-SRC_URI_append_class-target = " \
+-           file://0002-Using-native-binaries.patch \
+-           "
+-SRC_URI[sha256sum] = "bc42b7f8495b9bfc7f7850dd180bb02a5bdf139cc232b8c6f02a6967e20714f2"
+-
+-S = "${WORKDIR}/node-v${PV}"
+-
+-# v8 errors out if you have set CCACHE
+-CCACHE = ""
+-
+-def map_nodejs_arch(a, d):
+-    import re
+-
+-    if   re.match('i.86$', a): return 'ia32'
+-    elif re.match('x86_64$', a): return 'x64'
+-    elif re.match('aarch64$', a): return 'arm64'
+-    elif re.match('(powerpc64|ppc64le)$', a): return 'ppc64'
+-    elif re.match('powerpc$', a): return 'ppc'
+-    return a
+-
+-ARCHFLAGS_arm = "${@bb.utils.contains('TUNE_FEATURES', 'callconvention-hard', '--with-arm-float-abi=hard', '--with-arm-float-abi=softfp', d)} \
+-                 ${@bb.utils.contains('TUNE_FEATURES', 'neon', '--with-arm-fpu=neon', \
+-                    bb.utils.contains('TUNE_FEATURES', 'vfpv3d16', '--with-arm-fpu=vfpv3-d16', \
+-                    bb.utils.contains('TUNE_FEATURES', 'vfpv3', '--with-arm-fpu=vfpv3', \
+-                    '--with-arm-fpu=vfp', d), d), d)}"
+-GYP_DEFINES_append_mipsel = " mips_arch_variant='r1' "
+-ARCHFLAGS ?= ""
+-
+-PACKAGECONFIG ??= "ares brotli icu zlib"
+-
+-PACKAGECONFIG[ares] = "--shared-cares,,c-ares"
+-PACKAGECONFIG[brotli] = "--shared-brotli,,brotli"
+-PACKAGECONFIG[icu] = "--with-intl=system-icu,--without-intl,icu"
+-PACKAGECONFIG[libuv] = "--shared-libuv,,libuv"
+-PACKAGECONFIG[nghttp2] = "--shared-nghttp2,,nghttp2"
+-PACKAGECONFIG[shared] = "--shared"
+-PACKAGECONFIG[zlib] = "--shared-zlib,,zlib"
+-
+-# We don't want to cross-compile during target compile,
+-# and we need to use the right flags during host compile,
+-# too.
+-EXTRA_OEMAKE = "\
+-    CC.host='${CC}' \
+-    CFLAGS.host='${CPPFLAGS} ${CFLAGS}' \
+-    CXX.host='${CXX}' \
+-    CXXFLAGS.host='${CPPFLAGS} ${CXXFLAGS}' \
+-    LDFLAGS.host='${LDFLAGS}' \
+-    AR.host='${AR}' \
+-    \
+-    builddir_name=./ \
+-"
+-
+-python do_unpack() {
+-    import shutil
+-
+-    bb.build.exec_func('base_do_unpack', d)
+-
+-    shutil.rmtree(d.getVar('S') + '/deps/openssl', True)
+-    if 'ares' in d.getVar('PACKAGECONFIG'):
+-        shutil.rmtree(d.getVar('S') + '/deps/cares', True)
+-    if 'brotli' in d.getVar('PACKAGECONFIG'):
+-        shutil.rmtree(d.getVar('S') + '/deps/brotli', True)
+-    if 'libuv' in d.getVar('PACKAGECONFIG'):
+-        shutil.rmtree(d.getVar('S') + '/deps/uv', True)
+-    if 'nghttp2' in d.getVar('PACKAGECONFIG'):
+-        shutil.rmtree(d.getVar('S') + '/deps/nghttp2', True)
+-    if 'zlib' in d.getVar('PACKAGECONFIG'):
+-        shutil.rmtree(d.getVar('S') + '/deps/zlib', True)
+-}
+-
+-# Node is way too cool to use proper autotools, so we install two wrappers to forcefully inject proper arch cflags to workaround gypi
+-do_configure () {
+-    export LD="${CXX}"
+-    GYP_DEFINES="${GYP_DEFINES}" export GYP_DEFINES
+-    # $TARGET_ARCH settings don't match --dest-cpu settings
+-    python3 configure.py --prefix=${prefix} --cross-compiling --without-snapshot --shared-openssl \
+-               --without-dtrace \
+-               --without-etw \
+-               --dest-cpu="${@map_nodejs_arch(d.getVar('TARGET_ARCH'), d)}" \
+-               --dest-os=linux \
+-               --libdir=${D}${libdir} \
+-               ${ARCHFLAGS} \
+-               ${PACKAGECONFIG_CONFARGS}
+-}
+-
+-do_compile () {
+-    export LD="${CXX}"
+-    oe_runmake BUILDTYPE=Release
+-}
+-
+-do_install () {
+-    oe_runmake install DESTDIR=${D}
+-
+-    # wasn't updated since 2009 and is the only thing requiring python2 in runtime
+-    # ERROR: nodejs-12.14.1-r0 do_package_qa: QA Issue: /usr/lib/node_modules/npm/node_modules/node-gyp/gyp/samples/samples contained in package nodejs-npm requires /usr/bin/python, but no providers found in RDEPENDS_nodejs-npm? [file-rdeps]
+-    rm -f ${D}${exec_prefix}/lib/node_modules/npm/node_modules/node-gyp/gyp/samples/samples
+-}
+-
+-do_install_append_class-native() {
+-    # use node from PATH instead of absolute path to sysroot
+-    # node-v0.10.25/tools/install.py is using:
+-    # shebang = os.path.join(node_prefix, 'bin/node')
+-    # update_shebang(link_path, shebang)
+-    # and node_prefix can be very long path to bindir in native sysroot and
+-    # when it exceeds 128 character shebang limit it's stripped to incorrect path
+-    # and npm fails to execute like in this case with 133 characters show in log.do_install:
+-    # updating shebang of /home/jenkins/workspace/build-webos-nightly/device/qemux86/label/open-webos-builder/BUILD-qemux86/work/x86_64-linux/nodejs-native/0.10.15-r0/image/home/jenkins/workspace/build-webos-nightly/device/qemux86/label/open-webos-builder/BUILD-qemux86/sysroots/x86_64-linux/usr/bin/npm to /home/jenkins/workspace/build-webos-nightly/device/qemux86/label/open-webos-builder/BUILD-qemux86/sysroots/x86_64-linux/usr/bin/node
+-    # /usr/bin/npm is symlink to /usr/lib/node_modules/npm/bin/npm-cli.js
+-    # use sed on npm-cli.js because otherwise symlink is replaced with normal file and
+-    # npm-cli.js continues to use old shebang
+-    sed "1s^.*^#\!/usr/bin/env node^g" -i ${D}${exec_prefix}/lib/node_modules/npm/bin/npm-cli.js
+-
+-    # Install the native binaries to provide it within sysroot for the target compilation
+-    install -d ${D}${bindir}
+-    install -m 0755 ${S}/out/Release/torque ${D}${bindir}/torque
+-    install -m 0755 ${S}/out/Release/bytecode_builtins_list_generator ${D}${bindir}/bytecode_builtins_list_generator
+-    if ${@bb.utils.contains('PACKAGECONFIG','icu','true','false',d)}; then
+-        install -m 0755 ${S}/out/Release/gen-regexp-special-case ${D}${bindir}/gen-regexp-special-case
+-    fi
+-    install -m 0755 ${S}/out/Release/mkcodecache ${D}${bindir}/mkcodecache
+-    install -m 0755 ${S}/out/Release/node_mksnapshot ${D}${bindir}/node_mksnapshot
+-}
+-
+-do_install_append_class-target() {
+-    sed "1s^.*^#\!${bindir}/env node^g" -i ${D}${exec_prefix}/lib/node_modules/npm/bin/npm-cli.js
+-}
+-
+-PACKAGES =+ "${PN}-npm"
+-FILES_${PN}-npm = "${exec_prefix}/lib/node_modules ${bindir}/npm ${bindir}/npx"
+-RDEPENDS_${PN}-npm = "bash python3-core python3-shell python3-datetime \
+-    python3-misc python3-multiprocessing"
+-
+-PACKAGES =+ "${PN}-systemtap"
+-FILES_${PN}-systemtap = "${datadir}/systemtap"
+-
+-BBCLASSEXTEND = "native"
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs_14.18.1.bb b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs_14.18.1.bb
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs_14.18.1.bb	2024-06-21 09:02:03.000000000 +0200
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs_14.18.1.bb	1970-01-01 01:00:00.000000000 +0100
+@@ -1,209 +0,0 @@
+-DESCRIPTION = "nodeJS Evented I/O for V8 JavaScript"
+-HOMEPAGE = "http://nodejs.org"
+-LICENSE = "MIT & BSD & Artistic-2.0"
+-LIC_FILES_CHKSUM = "file://LICENSE;md5=6768abdfc4dae4fde59d6b4df96930f3"
+-
+-DEFAULT_PREFERENCE = "-1"
+-
+-DEPENDS = "openssl"
+-DEPENDS:append:class-target = " qemu-native"
+-DEPENDS:append:class-native = " c-ares-native"
+-
+-inherit pkgconfig python3native qemu
+-
+-COMPATIBLE_MACHINE:armv4 = "(!.*armv4).*"
+-COMPATIBLE_MACHINE:armv5 = "(!.*armv5).*"
+-COMPATIBLE_MACHINE:mips64 = "(!.*mips64).*"
+-
+-COMPATIBLE_HOST:riscv64 = "null"
+-COMPATIBLE_HOST:riscv32 = "null"
+-
+-SRC_URI = "http://nodejs.org/dist/v${PV}/node-v${PV}.tar.xz \
+-           file://0001-Disable-running-gyp-files-for-bundled-deps-nodejs14.patch \
+-           file://0003-Install-both-binaries-and-use-libdir-nodejs14.patch \
+-           file://0004-v8-don-t-override-ARM-CFLAGS.patch \
+-           file://big-endian.patch \
+-           file://mips-warnings.patch \
+-           file://mips-less-memory-nodejs14.patch \
+-           file://0001-jinja-tests.py-add-py-3.10-fix-nodejs14.patch \
+-           file://CVE-2022-32212.patch \
+-           file://CVE-2022-35255.patch \
+-           file://CVE-2022-43548.patch \
+-           file://gcc13.patch \
+-           "
+-SRC_URI:append:class-target = " \
+-           file://0002-Using-native-binaries-nodejs14.patch \
+-           "
+-SRC_URI:append:toolchain-clang:x86 = " \
+-           file://libatomic-nodejs14.patch \
+-           "
+-SRC_URI:append:toolchain-clang:powerpc64le = " \
+-           file://0001-ppc64-Do-not-use-mminimal-toc-with-clang-nodejs14.patch \
+-           "
+-SRC_URI[sha256sum] = "3fa1d71adddfab2f5e3e41874b4eddbdf92b65cade4a43922fb1e437afcf89ed"
+-
+-S = "${WORKDIR}/node-v${PV}"
+-
+-# v8 errors out if you have set CCACHE
+-CCACHE = ""
+-
+-def map_nodejs_arch(a, d):
+-    import re
+-
+-    if   re.match('i.86$', a): return 'ia32'
+-    elif re.match('x86_64$', a): return 'x64'
+-    elif re.match('aarch64$', a): return 'arm64'
+-    elif re.match('(powerpc64|powerpc64le|ppc64le)$', a): return 'ppc64'
+-    elif re.match('powerpc$', a): return 'ppc'
+-    return a
+-
+-ARCHFLAGS:arm = "${@bb.utils.contains('TUNE_FEATURES', 'callconvention-hard', '--with-arm-float-abi=hard', '--with-arm-float-abi=softfp', d)} \
+-                 ${@bb.utils.contains('TUNE_FEATURES', 'neon', '--with-arm-fpu=neon', \
+-                    bb.utils.contains('TUNE_FEATURES', 'vfpv3d16', '--with-arm-fpu=vfpv3-d16', \
+-                    bb.utils.contains('TUNE_FEATURES', 'vfpv3', '--with-arm-fpu=vfpv3', \
+-                    '--with-arm-fpu=vfp', d), d), d)}"
+-GYP_DEFINES:append:mipsel = " mips_arch_variant='r1' "
+-ARCHFLAGS ?= ""
+-
+-PACKAGECONFIG ??= "brotli icu zlib"
+-
+-PACKAGECONFIG[ares] = "--shared-cares,,c-ares"
+-PACKAGECONFIG[brotli] = "--shared-brotli,,brotli"
+-PACKAGECONFIG[icu] = "--with-intl=system-icu,--without-intl,icu"
+-PACKAGECONFIG[libuv] = "--shared-libuv,,libuv"
+-PACKAGECONFIG[nghttp2] = "--shared-nghttp2,,nghttp2"
+-PACKAGECONFIG[shared] = "--shared"
+-PACKAGECONFIG[zlib] = "--shared-zlib,,zlib"
+-
+-# We don't want to cross-compile during target compile,
+-# and we need to use the right flags during host compile,
+-# too.
+-EXTRA_OEMAKE = "\
+-    CC.host='${CC}' \
+-    CFLAGS.host='${CPPFLAGS} ${CFLAGS}' \
+-    CXX.host='${CXX}' \
+-    CXXFLAGS.host='${CPPFLAGS} ${CXXFLAGS}' \
+-    LDFLAGS.host='${LDFLAGS}' \
+-    AR.host='${AR}' \
+-    \
+-    builddir_name=./ \
+-"
+-
+-python do_unpack() {
+-    import shutil
+-
+-    bb.build.exec_func('base_do_unpack', d)
+-
+-    if 'ares' in d.getVar('PACKAGECONFIG'):
+-        shutil.rmtree(d.getVar('S') + '/deps/cares', True)
+-    if 'brotli' in d.getVar('PACKAGECONFIG'):
+-        shutil.rmtree(d.getVar('S') + '/deps/brotli', True)
+-    if 'libuv' in d.getVar('PACKAGECONFIG'):
+-        shutil.rmtree(d.getVar('S') + '/deps/uv', True)
+-    if 'nghttp2' in d.getVar('PACKAGECONFIG'):
+-        shutil.rmtree(d.getVar('S') + '/deps/nghttp2', True)
+-    if 'zlib' in d.getVar('PACKAGECONFIG'):
+-        shutil.rmtree(d.getVar('S') + '/deps/zlib', True)
+-}
+-
+-# V8's JIT infrastructure requires binaries such as mksnapshot and
+-# mkpeephole to be run in the host during the build. However, these
+-# binaries must have the same bit-width as the target (e.g. a x86_64
+-# host targeting ARMv6 needs to produce a 32-bit binary). Instead of
+-# depending on a third Yocto toolchain, we just build those binaries
+-# for the target and run them on the host with QEMU.
+-python do_create_v8_qemu_wrapper () {
+-    """Creates a small wrapper that invokes QEMU to run some target V8 binaries
+-    on the host."""
+-    qemu_libdirs = [d.expand('${STAGING_DIR_HOST}${libdir}'),
+-                    d.expand('${STAGING_DIR_HOST}${base_libdir}')]
+-    qemu_cmd = qemu_wrapper_cmdline(d, d.getVar('STAGING_DIR_HOST', True),
+-                                    qemu_libdirs)
+-    wrapper_path = d.expand('${B}/v8-qemu-wrapper.sh')
+-    with open(wrapper_path, 'w') as wrapper_file:
+-        wrapper_file.write("""#!/bin/sh
+-
+-# This file has been generated automatically.
+-# It invokes QEMU to run binaries built for the target in the host during the
+-# build process.
+-
+-%s "$@"
+-""" % qemu_cmd)
+-    os.chmod(wrapper_path, 0o755)
+-}
+-
+-do_create_v8_qemu_wrapper[dirs] = "${B}"
+-addtask create_v8_qemu_wrapper after do_configure before do_compile
+-
+-# Work around compatibility issues with gcc-13 on host
+-BUILD_CXXFLAGS += "-fpermissive"
+-
+-LDFLAGS:append:x86 = " -latomic"
+-
+-# Node is way too cool to use proper autotools, so we install two wrappers to forcefully inject proper arch cflags to workaround gypi
+-do_configure () {
+-    export LD="${CXX}"
+-    GYP_DEFINES="${GYP_DEFINES}" export GYP_DEFINES
+-    # $TARGET_ARCH settings don't match --dest-cpu settings
+-    python3 configure.py --prefix=${prefix} --cross-compiling \
+-               --without-dtrace \
+-               --without-etw \
+-               --dest-cpu="${@map_nodejs_arch(d.getVar('TARGET_ARCH'), d)}" \
+-               --dest-os=linux \
+-               --libdir=${D}${libdir} \
+-               ${ARCHFLAGS} \
+-               ${PACKAGECONFIG_CONFARGS}
+-}
+-
+-do_compile () {
+-    export LD="${CXX}"
+-    install -Dm 0755 ${B}/v8-qemu-wrapper.sh ${B}/out/Release/v8-qemu-wrapper.sh
+-    oe_runmake BUILDTYPE=Release
+-}
+-
+-do_install () {
+-    oe_runmake install DESTDIR=${D}
+-
+-    # wasn't updated since 2009 and is the only thing requiring python2 in runtime
+-    # ERROR: nodejs-12.14.1-r0 do_package_qa: QA Issue: /usr/lib/node_modules/npm/node_modules/node-gyp/gyp/samples/samples contained in package nodejs-npm requires /usr/bin/python, but no providers found in RDEPENDS:nodejs-npm? [file-rdeps]
+-    rm -f ${D}${exec_prefix}/lib/node_modules/npm/node_modules/node-gyp/gyp/samples/samples
+-}
+-
+-do_install:append:class-native() {
+-    # use node from PATH instead of absolute path to sysroot
+-    # node-v0.10.25/tools/install.py is using:
+-    # shebang = os.path.join(node_prefix, 'bin/node')
+-    # update_shebang(link_path, shebang)
+-    # and node_prefix can be very long path to bindir in native sysroot and
+-    # when it exceeds 128 character shebang limit it's stripped to incorrect path
+-    # and npm fails to execute like in this case with 133 characters show in log.do_install:
+-    # updating shebang of /home/jenkins/workspace/build-webos-nightly/device/qemux86/label/open-webos-builder/BUILD-qemux86/work/x86_64-linux/nodejs-native/0.10.15-r0/image/home/jenkins/workspace/build-webos-nightly/device/qemux86/label/open-webos-builder/BUILD-qemux86/sysroots/x86_64-linux/usr/bin/npm to /home/jenkins/workspace/build-webos-nightly/device/qemux86/label/open-webos-builder/BUILD-qemux86/sysroots/x86_64-linux/usr/bin/node
+-    # /usr/bin/npm is symlink to /usr/lib/node_modules/npm/bin/npm-cli.js
+-    # use sed on npm-cli.js because otherwise symlink is replaced with normal file and
+-    # npm-cli.js continues to use old shebang
+-    sed "1s^.*^#\!/usr/bin/env node^g" -i ${D}${exec_prefix}/lib/node_modules/npm/bin/npm-cli.js
+-
+-    # Install the native binaries to provide it within sysroot for the target compilation
+-    install -d ${D}${bindir}
+-    install -m 0755 ${S}/out/Release/torque ${D}${bindir}/torque
+-    install -m 0755 ${S}/out/Release/bytecode_builtins_list_generator ${D}${bindir}/bytecode_builtins_list_generator
+-    if ${@bb.utils.contains('PACKAGECONFIG','icu','true','false',d)}; then
+-        install -m 0755 ${S}/out/Release/gen-regexp-special-case ${D}${bindir}/gen-regexp-special-case
+-    fi
+-    install -m 0755 ${S}/out/Release/mkcodecache ${D}${bindir}/mkcodecache
+-    install -m 0755 ${S}/out/Release/node_mksnapshot ${D}${bindir}/node_mksnapshot
+-}
+-
+-do_install:append:class-target() {
+-    sed "1s^.*^#\!${bindir}/env node^g" -i ${D}${exec_prefix}/lib/node_modules/npm/bin/npm-cli.js
+-}
+-
+-PACKAGES =+ "${PN}-npm"
+-FILES:${PN}-npm = "${exec_prefix}/lib/node_modules ${bindir}/npm ${bindir}/npx"
+-RDEPENDS:${PN}-npm = "bash python3-core python3-shell python3-datetime \
+-    python3-misc python3-multiprocessing"
+-
+-PACKAGES =+ "${PN}-systemtap"
+-FILES:${PN}-systemtap = "${datadir}/systemtap"
+-
+-BBCLASSEXTEND = "native"
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs_18.17.1.bb b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs_18.17.1.bb
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs_18.17.1.bb	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs_18.17.1.bb	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,185 @@
++DESCRIPTION = "nodeJS Evented I/O for V8 JavaScript"
++HOMEPAGE = "http://nodejs.org"
++LICENSE = "MIT & ISC & BSD-2-Clause & BSD-3-Clause & Artistic-2.0 & Apache-2.0"
++LIC_FILES_CHKSUM = "file://LICENSE;md5=bc1f9ebe76be76f163e3b675303ad9cd"
++
++CVE_PRODUCT = "nodejs node.js"
++
++DEPENDS = "openssl file-replacement-native"
++DEPENDS_append_class-target = " qemu-native"
++DEPENDS_append_class-native = " c-ares-native"
++
++inherit pkgconfig python3native qemu ptest
++
++COMPATIBLE_MACHINE_armv4 = "(!.*armv4).*"
++COMPATIBLE_MACHINE_armv5 = "(!.*armv5).*"
++COMPATIBLE_MACHINE_mips64 = "(!.*mips64).*"
++
++COMPATIBLE_HOST_riscv64 = "null"
++COMPATIBLE_HOST_riscv32 = "null"
++COMPATIBLE_HOST_powerpc = "null"
++
++SRC_URI = "http://nodejs.org/dist/v${PV}/node-v${PV}.tar.xz \
++           file://0001-Disable-running-gyp-files-for-bundled-deps.patch \
++           file://0004-v8-don-t-override-ARM-CFLAGS.patch \
++           file://big-endian.patch \
++           file://mips-less-memory.patch \
++           file://system-c-ares.patch \
++           file://0001-liftoff-Correct-function-signatures.patch \
++           file://0001-mips-Use-32bit-cast-for-operand-on-mips32.patch \
++           file://run-ptest \
++           "
++
++SRC_URI_append_class-target = " \
++           file://0001-Using-native-binaries.patch \
++           "
++SRC_URI_append_toolchain-clang_x86 = " \
++           file://libatomic.patch \
++           "
++SRC_URI_append_toolchain-clang_powerpc64le = " \
++           file://0001-ppc64-Do-not-use-mminimal-toc-with-clang.patch \
++           "
++SRC_URI[sha256sum] = "f215cf03d0f00f07ac0b674c6819f804c1542e16f152da04980022aeccf5e65a"
++
++S = "${WORKDIR}/node-v${PV}"
++
++# v8 errors out if you have set CCACHE
++CCACHE = ""
++
++def map_nodejs_arch(a, d):
++    import re
++
++    if   re.match('i.86$', a): return 'ia32'
++    elif re.match('x86_64$', a): return 'x64'
++    elif re.match('aarch64$', a): return 'arm64'
++    elif re.match('(powerpc64|powerpc64le|ppc64le)$', a): return 'ppc64'
++    elif re.match('powerpc$', a): return 'ppc'
++    return a
++
++ARCHFLAGS_arm = "${@bb.utils.contains('TUNE_FEATURES', 'callconvention-hard', '--with-arm-float-abi=hard', '--with-arm-float-abi=softfp', d)} \
++                 ${@bb.utils.contains('TUNE_FEATURES', 'neon', '--with-arm-fpu=neon', \
++                    bb.utils.contains('TUNE_FEATURES', 'vfpv3d16', '--with-arm-fpu=vfpv3-d16', \
++                    bb.utils.contains('TUNE_FEATURES', 'vfpv3', '--with-arm-fpu=vfpv3', \
++                    '--with-arm-fpu=vfp', d), d), d)}"
++ARCHFLAGS_append_mips = " --v8-lite-mode"
++ARCHFLAGS_append_mipsel = " --v8-lite-mode"
++ARCHFLAGS ?= ""
++
++PACKAGECONFIG ??= "ares brotli icu zlib"
++
++PACKAGECONFIG[ares] = "--shared-cares,,c-ares"
++PACKAGECONFIG[brotli] = "--shared-brotli,,brotli"
++PACKAGECONFIG[icu] = "--with-intl=system-icu,--without-intl,icu"
++PACKAGECONFIG[libuv] = "--shared-libuv,,libuv"
++PACKAGECONFIG[nghttp2] = "--shared-nghttp2,,nghttp2"
++PACKAGECONFIG[shared] = "--shared"
++PACKAGECONFIG[zlib] = "--shared-zlib,,zlib"
++
++# We don't want to cross-compile during target compile,
++# and we need to use the right flags during host compile,
++# too.
++EXTRA_OEMAKE = "\
++    CC.host='${CC} -pie -fPIE' \
++    CFLAGS.host='${CPPFLAGS} ${CFLAGS}' \
++    CXX.host='${CXX} -pie -fPIE' \
++    CXXFLAGS.host='${CPPFLAGS} ${CXXFLAGS}' \
++    LDFLAGS.host='${LDFLAGS}' \
++    AR.host='${AR}' \
++    \
++    builddir_name=./ \
++"
++
++EXTRANATIVEPATH += "file-native"
++
++python prune_sources() {
++    import shutil
++
++    shutil.rmtree(d.getVar('S') + '/deps/openssl')
++    if 'ares' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/cares')
++    if 'brotli' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/brotli')
++    if 'libuv' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/uv')
++    if 'nghttp2' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/nghttp2')
++    if 'zlib' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/zlib')
++}
++do_unpack[postfuncs] += "prune_sources"
++
++# V8's JIT infrastructure requires binaries such as mksnapshot and
++# mkpeephole to be run in the host during the build. However, these
++# binaries must have the same bit-width as the target (e.g. a x86_64
++# host targeting ARMv6 needs to produce a 32-bit binary). Instead of
++# depending on a third Yocto toolchain, we just build those binaries
++# for the target and run them on the host with QEMU.
++python do_create_v8_qemu_wrapper () {
++    """Creates a small wrapper that invokes QEMU to run some target V8 binaries
++    on the host."""
++    qemu_libdirs = [d.expand('${STAGING_DIR_HOST}${libdir}'),
++                    d.expand('${STAGING_DIR_HOST}${base_libdir}')]
++    qemu_cmd = qemu_wrapper_cmdline(d, d.getVar('STAGING_DIR_HOST'),
++                                    qemu_libdirs)
++    wrapper_path = d.expand('${B}/v8-qemu-wrapper.sh')
++    with open(wrapper_path, 'w') as wrapper_file:
++        wrapper_file.write("""#!/bin/sh
++
++# This file has been generated automatically.
++# It invokes QEMU to run binaries built for the target in the host during the
++# build process.
++
++%s "$@"
++""" % qemu_cmd)
++    os.chmod(wrapper_path, 0o755)
++}
++
++do_create_v8_qemu_wrapper[dirs] = "${B}"
++addtask create_v8_qemu_wrapper after do_configure before do_compile
++
++LDFLAGS_append_x86 = " -latomic"
++
++CROSS_FLAGS = "--cross-compiling"
++CROSS_FLAGS_class-native = "--no-cross-compiling"
++
++# Node is way too cool to use proper autotools, so we install two wrappers to forcefully inject proper arch cflags to workaround gypi
++do_configure () {
++    GYP_DEFINES="${GYP_DEFINES}" export GYP_DEFINES
++    # $TARGET_ARCH settings don't match --dest-cpu settings
++    python3 configure.py --verbose --prefix=${prefix} \
++               --shared-openssl \
++               --without-dtrace \
++               --without-etw \
++               --dest-cpu="${@map_nodejs_arch(d.getVar('TARGET_ARCH'), d)}" \
++               --dest-os=linux \
++               --libdir=${baselib} \
++               ${CROSS_FLAGS} \
++               ${ARCHFLAGS} \
++               ${PACKAGECONFIG_CONFARGS}
++}
++
++do_compile () {
++    install -D ${RECIPE_SYSROOT_NATIVE}/etc/ssl/openssl.cnf ${B}/deps/openssl/nodejs-openssl.cnf
++    install -D ${B}/v8-qemu-wrapper.sh ${B}/out/Release/v8-qemu-wrapper.sh
++    oe_runmake BUILDTYPE=Release
++}
++
++do_install () {
++    oe_runmake install DESTDIR=${D}
++}
++
++do_install_ptest () {
++    cp -r  ${B}/out/Release/cctest ${D}${PTEST_PATH}/
++    cp -r ${B}/test ${D}${PTEST_PATH}
++    chown -R root:root ${D}${PTEST_PATH}
++}
++
++PACKAGES =+ "${PN}-npm"
++FILES_${PN}-npm = "${nonarch_libdir}/node_modules ${bindir}/npm ${bindir}/npx ${bindir}/corepack"
++RDEPENDS_${PN}-npm = "bash python3-core python3-shell python3-datetime \
++    python3-misc python3-multiprocessing"
++
++PACKAGES =+ "${PN}-systemtap"
++FILES_${PN}-systemtap = "${datadir}/systemtap"
++
++BBCLASSEXTEND = "native"
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs-oe-cache-18.17/oe-npm-cache b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs-oe-cache-18.17/oe-npm-cache
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs-oe-cache-18.17/oe-npm-cache	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs-oe-cache-18.17/oe-npm-cache	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,77 @@
++#!/usr/bin/env node
++
++/// Usage: oe-npm-cache <cache-dir> <type> <key> <file-name>
++///    <type> ... meta - metainformation about package
++///               tgz  - tarball
++
++const process = require("node:process");
++
++module.paths.unshift("@@libdir@@/node_modules/npm/node_modules");
++
++const cacache = require('cacache')
++const fs = require('fs')
++
++// argv[0] is 'node', argv[1] is this script
++const cache_dir = process.argv[2]
++const type      = process.argv[3]
++const key       = process.argv[4]
++const file      = process.argv[5]
++
++const data = fs.readFileSync(file)
++
++// metadata content is highly nodejs dependent; when cache entries are not
++// found, place debug statements in 'make-fetch-happen/lib/cache/policy.js'
++// (CachePolicy::satisfies())
++const xlate = {
++    'meta': {
++	'key_prefix': 'make-fetch-happen:request-cache:',
++	'metadata': function() {
++	    return {
++		time: Date.now(),
++		url:  key,
++		reqHeaders: {
++		    'accept': 'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*',
++		},
++		resHeaders: {
++		    "content-type": "application/json",
++		    "status": 200,
++		},
++		options: {
++		    compress: true,
++		}
++	    };
++	},
++    },
++
++    'tgz': {
++	'key_prefix': 'make-fetch-happen:request-cache:',
++	'metadata': function() {
++	    return {
++		time: Date.now(),
++		url:  key,
++		reqHeaders: {
++		    'accept': '*/*',
++		},
++		resHeaders: {
++		    "content-type": "application/octet-stream",
++		    "status": 200,
++		},
++		options: {
++		    compress: true,
++		},
++	    };
++	},
++    },
++};
++
++const info = xlate[type];
++let opts = {}
++
++if (info.metadata) {
++    opts['metadata'] = info.metadata();
++}
++
++cacache.put(cache_dir, info.key_prefix + key, data, opts)
++    .then(integrity => {
++	console.log(`Saved content of ${key} (${file}).`);
++})
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs-oe-cache-native_18.17.bb b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs-oe-cache-native_18.17.bb
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs-oe-cache-native_18.17.bb	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs/nodejs-oe-cache-native_18.17.bb	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,21 @@
++DESCRIPTION = "OE helper for manipulating npm cache"
++LICENSE = "Apache-2.0"
++LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
++
++SRC_URI = "\
++    file://oe-npm-cache \
++"
++
++inherit native
++
++B = "${WORKDIR}/build"
++
++do_configure() {
++    sed -e 's!@@libdir@@!${libdir}!g' < '${WORKDIR}/oe-npm-cache' > '${B}/oe-npm-cache'
++}
++
++do_install() {
++    install -D -p -m 0755 ${B}/oe-npm-cache ${D}${bindir}/oe-npm-cache
++}
++
++RDEPENDS:${PN} = "nodejs-native"
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-Disable-running-gyp-files-for-bundled-deps-nodejs14.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-Disable-running-gyp-files-for-bundled-deps-nodejs14.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-Disable-running-gyp-files-for-bundled-deps-nodejs14.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-Disable-running-gyp-files-for-bundled-deps-nodejs14.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,22 @@
++From 7d94bfe53beeb2d25eb5f2ff6b1d509df7e6ab80 Mon Sep 17 00:00:00 2001
++From: Zuzana Svetlikova <zsvetlik@redhat.com>
++Date: Thu, 27 Apr 2017 14:25:42 +0200
++Subject: [PATCH] Disable running gyp on shared deps
++
++---
++ Makefile | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/Makefile b/Makefile
++index 93d63110..79caaec2 100644
++--- a/Makefile
+++++ b/Makefile
++@@ -138,7 +138,7 @@ with-code-cache test-code-cache:
++	$(warning '$@' target is a noop)
++
++ out/Makefile: config.gypi common.gypi node.gyp \
++-	deps/uv/uv.gyp deps/llhttp/llhttp.gyp deps/zlib/zlib.gyp \
+++	deps/llhttp/llhttp.gyp \
++	tools/v8_gypfiles/toolchain.gypi tools/v8_gypfiles/features.gypi \
++	tools/v8_gypfiles/inspector.gypi tools/v8_gypfiles/v8.gyp
++	$(PYTHON) tools/gyp_node.py -f make
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-Disable-running-gyp-files-for-bundled-deps.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-Disable-running-gyp-files-for-bundled-deps.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-Disable-running-gyp-files-for-bundled-deps.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-Disable-running-gyp-files-for-bundled-deps.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,25 @@
++From c2aff16cc196a61f4ab1cdae4a91c7926123c239 Mon Sep 17 00:00:00 2001
++From: Zuzana Svetlikova <zsvetlik@redhat.com>
++Date: Thu, 27 Apr 2017 14:25:42 +0200
++Subject: [PATCH] Disable running gyp on shared deps
++
++---
++ Makefile | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/Makefile b/Makefile
++index 0947300f24..6c98691984 100644
++--- a/Makefile
+++++ b/Makefile
++@@ -141,7 +141,7 @@ test-code-cache: with-code-cache
++ 	echo "'test-code-cache' target is a noop"
++ 
++ out/Makefile: config.gypi common.gypi node.gyp \
++-	deps/uv/uv.gyp deps/http_parser/http_parser.gyp deps/zlib/zlib.gyp \
+++	deps/http_parser/http_parser.gyp \
++ 	tools/v8_gypfiles/toolchain.gypi tools/v8_gypfiles/features.gypi \
++ 	tools/v8_gypfiles/inspector.gypi tools/v8_gypfiles/v8.gyp
++ 	$(PYTHON) tools/gyp_node.py -f make
++-- 
++2.20.1
++
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-jinja-tests.py-add-py-3.10-fix-nodejs14.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-jinja-tests.py-add-py-3.10-fix-nodejs14.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-jinja-tests.py-add-py-3.10-fix-nodejs14.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-jinja-tests.py-add-py-3.10-fix-nodejs14.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,40 @@
++From e1d838089cd461d9efcf4d29d9f18f65994d2d6b Mon Sep 17 00:00:00 2001
++From: Alexander Kanavin <alex@linutronix.de>
++Date: Sun, 3 Oct 2021 22:48:39 +0200
++Subject: [PATCH] jinja/tests.py: add py 3.10 fix
++
++Upstream-Status: Pending
++Signed-off-by: Alexander Kanavin <alex@linutronix.de>
++---
++ deps/v8/third_party/jinja2/tests.py      | 2 +-
++ tools/inspector_protocol/jinja2/tests.py | 2 +-
++ 2 files changed, 2 insertions(+), 2 deletions(-)
++
++diff --git a/deps/v8/third_party/jinja2/tests.py b/deps/v8/third_party/jinja2/tests.py
++index 0adc3d4..b14f85f 100644
++--- a/deps/v8/third_party/jinja2/tests.py
+++++ b/deps/v8/third_party/jinja2/tests.py
++@@ -10,7 +10,7 @@
++ """
++ import operator
++ import re
++-from collections import Mapping
+++from collections.abc import Mapping
++ from jinja2.runtime import Undefined
++ from jinja2._compat import text_type, string_types, integer_types
++ import decimal
++diff --git a/tools/inspector_protocol/jinja2/tests.py b/tools/inspector_protocol/jinja2/tests.py
++index 0adc3d4..b14f85f 100644
++--- a/tools/inspector_protocol/jinja2/tests.py
+++++ b/tools/inspector_protocol/jinja2/tests.py
++@@ -10,7 +10,7 @@
++ """
++ import operator
++ import re
++-from collections import Mapping
+++from collections.abc import Mapping
++ from jinja2.runtime import Undefined
++ from jinja2._compat import text_type, string_types, integer_types
++ import decimal
++--
++2.20.1
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-ppc64-Do-not-use-mminimal-toc-with-clang-nodejs14.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-ppc64-Do-not-use-mminimal-toc-with-clang-nodejs14.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-ppc64-Do-not-use-mminimal-toc-with-clang-nodejs14.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-ppc64-Do-not-use-mminimal-toc-with-clang-nodejs14.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,27 @@
++From 0976af0f3b328436ea44a74a406f311adb2ab211 Mon Sep 17 00:00:00 2001
++From: Khem Raj <raj.khem@gmail.com>
++Date: Tue, 15 Jun 2021 19:01:31 -0700
++Subject: [PATCH] ppc64: Do not use -mminimal-toc with clang
++
++clang does not support this option
++
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++---
++ common.gypi | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/common.gypi b/common.gypi
++index ee91fb1d..049c8f8c 100644
++--- a/common.gypi
+++++ b/common.gypi
++@@ -413,7 +413,7 @@
++             'ldflags': [ '-m32' ],
++           }],
++           [ 'target_arch=="ppc64" and OS!="aix"', {
++-            'cflags': [ '-m64', '-mminimal-toc' ],
+++            'cflags': [ '-m64' ],
++             'ldflags': [ '-m64' ],
++           }],
++           [ 'target_arch=="s390x"', {
++--
++2.32.0
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-Remove-use-of-register-r7-because-llvm-now-issues-an.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-Remove-use-of-register-r7-because-llvm-now-issues-an.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-Remove-use-of-register-r7-because-llvm-now-issues-an.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0001-Remove-use-of-register-r7-because-llvm-now-issues-an.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,53 @@
++From be8d3cd6eab4b8f9849133060abb1aba4400276b Mon Sep 17 00:00:00 2001
++From: Amy Huang <akhuang@google.com>
++Date: Thu, 23 Apr 2020 11:25:53 -0700
++Subject: [PATCH] Remove use of register r7 because llvm now issues an error
++ when "r7" is used (starting in commit d85b3877)
++
++Bug: chromium:1073270
++Change-Id: I7ec8112f170b98d2edaf92bc9341e738f8de07a3
++Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/2163435
++Reviewed-by: Nico Weber <thakis@chromium.org>
++Reviewed-by: Ross McIlroy <rmcilroy@chromium.org>
++Commit-Queue: Nico Weber <thakis@chromium.org>
++Cr-Commit-Position: refs/heads/master@{#67371}
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++---
++Upstream-Status: Backport [https://chromium.googlesource.com/v8/v8/+/00604cd2806b5d26bef592dd19989a234bd07a4b%5E%21/]
++ deps/v8/src/codegen/arm/cpu-arm.cc | 13 -------------
++ 1 file changed, 13 deletions(-)
++
++diff --git a/deps/v8/src/codegen/arm/cpu-arm.cc b/deps/v8/src/codegen/arm/cpu-arm.cc
++index 868f360..654d68f 100644
++--- a/deps/v8/src/codegen/arm/cpu-arm.cc
+++++ b/deps/v8/src/codegen/arm/cpu-arm.cc
++@@ -30,18 +30,6 @@ V8_NOINLINE void CpuFeatures::FlushICache(void* start, size_t size) {
++   register uint32_t end asm("r1") = beg + size;
++   register uint32_t flg asm("r2") = 0;
++ 
++-#ifdef __clang__
++-  // This variant of the asm avoids a constant pool entry, which can be
++-  // problematic when LTO'ing. It is also slightly shorter.
++-  register uint32_t scno asm("r7") = __ARM_NR_cacheflush;
++-
++-  asm volatile("svc 0\n"
++-               :
++-               : "r"(beg), "r"(end), "r"(flg), "r"(scno)
++-               : "memory");
++-#else
++-  // Use a different variant of the asm with GCC because some versions doesn't
++-  // support r7 as an asm input.
++   asm volatile(
++       // This assembly works for both ARM and Thumb targets.
++ 
++@@ -59,7 +47,6 @@ V8_NOINLINE void CpuFeatures::FlushICache(void* start, size_t size) {
++       : "r"(beg), "r"(end), "r"(flg), [scno] "i"(__ARM_NR_cacheflush)
++       : "memory");
++ #endif
++-#endif
++ #endif  // !USE_SIMULATOR
++ }
++ 
++-- 
++2.29.2
++
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0002-Using-native-binaries-nodejs14.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0002-Using-native-binaries-nodejs14.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0002-Using-native-binaries-nodejs14.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0002-Using-native-binaries-nodejs14.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,62 @@
++From 6c3ac20477a4bac643088f24df3c042e627fafa9 Mon Sep 17 00:00:00 2001
++From: Guillaume Burel <guillaume.burel@stormshield.eu>
++Date: Fri, 3 Jan 2020 11:25:54 +0100
++Subject: [PATCH] Using native binaries
++
++---
++ node.gyp                 |  4 ++--
++ tools/v8_gypfiles/v8.gyp | 11 ++++-------
++ 2 files changed, 6 insertions(+), 9 deletions(-)
++
++--- a/node.gyp
+++++ b/node.gyp
++@@ -487,6 +487,7 @@
++               'action_name': 'run_mkcodecache',
++               'process_outputs_as_sources': 1,
++               'inputs': [
+++                '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
++                 '<(mkcodecache_exec)',
++               ],
++               'outputs': [
++@@ -512,6 +513,7 @@
++               'action_name': 'node_mksnapshot',
++               'process_outputs_as_sources': 1,
++               'inputs': [
+++                '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
++                 '<(node_mksnapshot_exec)',
++               ],
++               'outputs': [
++--- a/tools/v8_gypfiles/v8.gyp
+++++ b/tools/v8_gypfiles/v8.gyp
++@@ -220,6 +220,7 @@
++         {
++           'action_name': 'run_torque_action',
++           'inputs': [  # Order matters.
+++            '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
++             '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)torque<(EXECUTABLE_SUFFIX)',
++             '<@(torque_files)',
++           ],
++@@ -351,6 +352,7 @@
++         {
++           'action_name': 'generate_bytecode_builtins_list_action',
++           'inputs': [
+++            '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
++             '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)bytecode_builtins_list_generator<(EXECUTABLE_SUFFIX)',
++           ],
++           'outputs': [
++@@ -533,6 +535,7 @@
++             ],
++           },
++           'inputs': [
+++            '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
++             '<(mksnapshot_exec)',
++           ],
++           'outputs': [
++@@ -1448,6 +1451,7 @@
++         {
++           'action_name': 'run_gen-regexp-special-case_action',
++           'inputs': [
+++            '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
++             '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)gen-regexp-special-case<(EXECUTABLE_SUFFIX)',
++           ],
++           'outputs': [
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0002-Using-native-binaries.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0002-Using-native-binaries.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0002-Using-native-binaries.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0002-Using-native-binaries.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,71 @@
++From 6c3ac20477a4bac643088f24df3c042e627fafa9 Mon Sep 17 00:00:00 2001
++From: Guillaume Burel <guillaume.burel@stormshield.eu>
++Date: Fri, 3 Jan 2020 11:25:54 +0100
++Subject: [PATCH] Using native binaries
++
++---
++ node.gyp                 |  4 ++--
++ tools/v8_gypfiles/v8.gyp | 11 ++++-------
++ 2 files changed, 6 insertions(+), 9 deletions(-)
++
++diff --git a/node.gyp b/node.gyp
++index 8f4dc518..d9389190 100644
++--- a/node.gyp
+++++ b/node.gyp
++@@ -446,7 +446,7 @@
++                 '<(SHARED_INTERMEDIATE_DIR)/node_code_cache.cc',
++               ],
++               'action': [
++-                '<@(_inputs)',
+++                'mkcodecache',
++                 '<@(_outputs)',
++               ],
++             },
++@@ -471,7 +471,7 @@
++                 '<(SHARED_INTERMEDIATE_DIR)/node_snapshot.cc',
++               ],
++               'action': [
++-                '<@(_inputs)',
+++                'node_mksnapshot',
++                 '<@(_outputs)',
++               ],
++             },
++diff --git a/tools/v8_gypfiles/v8.gyp b/tools/v8_gypfiles/v8.gyp
++index a506a67d..c91f7dde 100644
++--- a/tools/v8_gypfiles/v8.gyp
+++++ b/tools/v8_gypfiles/v8.gyp
++@@ -140,7 +140,8 @@
++             '<@(torque_outputs)',
++           ],
++           'action': [
++-            '<@(_inputs)',
+++            'torque',
+++            '<@(torque_files)',
++             '-o', '<(torque_output_root)/torque-generated',
++             '-v8-root', '<(V8_ROOT)'
++           ],
++@@ -247,9 +248,7 @@
++             '<(generate_bytecode_builtins_list_output)',
++           ],
++           'action': [
++-            'python',
++-            '<(V8_ROOT)/tools/run.py',
++-            '<@(_inputs)',
+++            'bytecode_builtins_list_generator',
++             '<@(_outputs)',
++           ],
++         },
++@@ -1396,9 +1395,7 @@
++             '<(SHARED_INTERMEDIATE_DIR)/src/regexp/special-case.cc',
++           ],
++           'action': [
++-            'python',
++-            '<(V8_ROOT)/tools/run.py',
++-            '<@(_inputs)',
+++            'gen-regexp-special-case',
++             '<@(_outputs)',
++           ],
++         },
++-- 
++2.20.1
++
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0003-Install-both-binaries-and-use-libdir-nodejs14.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0003-Install-both-binaries-and-use-libdir-nodejs14.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0003-Install-both-binaries-and-use-libdir-nodejs14.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0003-Install-both-binaries-and-use-libdir-nodejs14.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,84 @@
++From 5b22fac923d1ca3e9fefb97f5a171124a88f5e22 Mon Sep 17 00:00:00 2001
++From: Elliott Sales de Andrade <quantum.analyst@gmail.com>
++Date: Tue, 19 Mar 2019 23:22:40 -0400
++Subject: [PATCH] Install both binaries and use libdir.
++MIME-Version: 1.0
++Content-Type: text/plain; charset=UTF-8
++Content-Transfer-Encoding: 8bit
++
++This allows us to build with a shared library for other users while
++still providing the normal executable.
++
++Taken from - https://src.fedoraproject.org/rpms/nodejs/raw/rawhide/f/0002-Install-both-binaries-and-use-libdir.patch
++
++Upstream-Status: Pending
++
++Signed-off-by: Elliott Sales de Andrade <quantum.analyst@gmail.com>
++Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++---
++ configure.py     |  7 +++++++
++ tools/install.py | 21 +++++++++------------
++ 2 files changed, 16 insertions(+), 12 deletions(-)
++
++diff --git a/configure.py b/configure.py
++index e6f7e4db..6cf5c45d 100755
++--- a/configure.py
+++++ b/configure.py
++@@ -626,6 +626,12 @@ parser.add_option('--shared',
++     help='compile shared library for embedding node in another project. ' +
++          '(This mode is not officially supported for regular applications)')
++
+++parser.add_option('--libdir',
+++    action='store',
+++    dest='libdir',
+++    default='lib',
+++    help='a directory to install the shared library into')
+++
++ parser.add_option('--without-v8-platform',
++     action='store_true',
++     dest='without_v8_platform',
++@@ -1202,6 +1208,7 @@ def configure_node(o):
++   o['variables']['node_no_browser_globals'] = b(options.no_browser_globals)
++
++   o['variables']['node_shared'] = b(options.shared)
+++  o['variables']['libdir'] = options.libdir
++   node_module_version = getmoduleversion.get_version()
++
++   if options.dest_os == 'android':
++diff --git a/tools/install.py b/tools/install.py
++index 729b416f..9bfc6234 100755
++--- a/tools/install.py
+++++ b/tools/install.py
++@@ -121,22 +121,19 @@ def subdir_files(path, dest, action):
++
++ def files(action):
++   is_windows = sys.platform == 'win32'
++-  output_file = 'node'
++   output_prefix = 'out/Release/'
+++  output_libprefix = output_prefix
++
++-  if 'false' == variables.get('node_shared'):
++-    if is_windows:
++-      output_file += '.exe'
+++  if is_windows:
+++    output_bin = 'node.exe'
+++    output_lib = 'node.dll'
++   else:
++-    if is_windows:
++-      output_file += '.dll'
++-    else:
++-      output_file = 'lib' + output_file + '.' + variables.get('shlib_suffix')
+++    output_bin = 'node'
+++    output_lib = 'libnode.' + variables.get('shlib_suffix')
++
++-  if 'false' == variables.get('node_shared'):
++-    action([output_prefix + output_file], 'bin/' + output_file)
++-  else:
++-    action([output_prefix + output_file], 'lib/' + output_file)
+++  action([output_prefix + output_bin], 'bin/' + output_bin)
+++  if 'true' == variables.get('node_shared'):
+++    action([output_libprefix + output_lib], variables.get('libdir') + '/' + output_lib)
++
++   if 'true' == variables.get('node_use_dtrace'):
++     action(['out/Release/node.d'], 'lib/dtrace/node.d')
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0003-Install-both-binaries-and-use-libdir.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0003-Install-both-binaries-and-use-libdir.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0003-Install-both-binaries-and-use-libdir.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0003-Install-both-binaries-and-use-libdir.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,87 @@
++From 5bfeffdf4b5de1c60a2ff0d1ddf65db2bb9a1533 Mon Sep 17 00:00:00 2001
++From: Elliott Sales de Andrade <quantum.analyst@gmail.com>
++Date: Tue, 19 Mar 2019 23:22:40 -0400
++Subject: [PATCH 3/3] Install both binaries and use libdir.
++
++This allows us to build with a shared library for other users while
++still providing the normal executable.
++
++Signed-off-by: Elliott Sales de Andrade <quantum.analyst@gmail.com>
++
++Stolen from [1]
++
++[1] https://src.fedoraproject.org/rpms/nodejs/raw/master/f/0003-Install-both-binaries-and-use-libdir.patch
++
++Upstream-Status: Pending
++
++Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>
++---
++ configure.py     |  7 +++++++
++ tools/install.py | 31 ++++++++++++++-----------------
++ 2 files changed, 21 insertions(+), 17 deletions(-)
++
++--- a/configure.py
+++++ b/configure.py
++@@ -602,6 +602,12 @@ parser.add_option('--shared',
++     help='compile shared library for embedding node in another project. ' +
++          '(This mode is not officially supported for regular applications)')
++ 
+++parser.add_option('--libdir',
+++    action='store',
+++    dest='libdir',
+++    default='lib',
+++    help='a directory to install the shared library into')
+++
++ parser.add_option('--without-v8-platform',
++     action='store_true',
++     dest='without_v8_platform',
++@@ -1168,6 +1174,7 @@ def configure_node(o):
++   o['variables']['node_no_browser_globals'] = b(options.no_browser_globals)
++ 
++   o['variables']['node_shared'] = b(options.shared)
+++  o['variables']['libdir'] = options.libdir
++   node_module_version = getmoduleversion.get_version()
++ 
++   if options.dest_os == 'android':
++--- a/tools/install.py
+++++ b/tools/install.py
++@@ -121,26 +121,23 @@ def subdir_files(path, dest, action):
++ 
++ def files(action):
++   is_windows = sys.platform == 'win32'
++-  output_file = 'node'
++   output_prefix = 'out/Release/'
+++  output_libprefix = output_prefix
++ 
++-  if 'false' == variables.get('node_shared'):
++-    if is_windows:
++-      output_file += '.exe'
+++  if is_windows:
+++    output_bin = 'node.exe'
+++    output_lib = 'node.dll'
++   else:
++-    if is_windows:
++-      output_file += '.dll'
++-    else:
++-      output_file = 'lib' + output_file + '.' + variables.get('shlib_suffix')
++-      # GYP will output to lib.target except on OS X, this is hardcoded
++-      # in its source - see the _InstallableTargetInstallPath function.
++-      if sys.platform != 'darwin':
++-        output_prefix += 'lib.target/'
+++    output_bin = 'node'
+++    output_lib = 'libnode.' + variables.get('shlib_suffix')
+++    # GYP will output to lib.target except on OS X, this is hardcoded
+++    # in its source - see the _InstallableTargetInstallPath function.
+++    if sys.platform != 'darwin':
+++      output_libprefix += 'lib.target/'
++ 
++-  if 'false' == variables.get('node_shared'):
++-    action([output_prefix + output_file], 'bin/' + output_file)
++-  else:
++-    action([output_prefix + output_file], 'lib/' + output_file)
+++  action([output_prefix + output_bin], 'bin/' + output_bin)
+++  if 'true' == variables.get('node_shared'):
+++    action([output_libprefix + output_lib], variables.get('libdir') + '/' + output_lib)
++ 
++   if 'true' == variables.get('node_use_dtrace'):
++     action(['out/Release/node.d'], 'lib/dtrace/node.d')
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0004-v8-don-t-override-ARM-CFLAGS.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0004-v8-don-t-override-ARM-CFLAGS.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0004-v8-don-t-override-ARM-CFLAGS.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/0004-v8-don-t-override-ARM-CFLAGS.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,102 @@
++From 47ee5cc5501289205d3e8e9f27ea9daf18cebac1 Mon Sep 17 00:00:00 2001
++From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <git@andred.net>
++Date: Sat, 9 Nov 2019 14:45:30 +0000
++Subject: [PATCH] v8: don't override ARM CFLAGS
++MIME-Version: 1.0
++Content-Type: text/plain; charset=UTF-8
++Content-Transfer-Encoding: 8bit
++
++This overrides yocto-provided build flags with its own, e.g we get
++    arm-poky-linux-musleabi-g++  -mthumb -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a7 \
++                                 ... \
++                                  -march=armv7-a -mfpu=neon -mfloat-abi=hard -marm
++
++Causing the latter to override the former, and compiler warnings:
++    cc1plus: warning: switch '-mcpu=cortex-a7' conflicts with '-march=armv7-a' switch
++
++Patch this out, so that yocto-provided flags take precedence.
++Note that in reality the same should probably be done for all the other
++supported architectures, too.
++
++Note that this also switches to Thumb(2) mode (in my case). No obvious
++problems have been noted during compilation or runtime.
++
++Upstream-Status: Inappropriate [oe-specific]
++Signed-off-by: André Draszik <git@andred.net>
++---
++ tools/v8_gypfiles/toolchain.gypi | 52 ++------------------------------
++ 1 file changed, 2 insertions(+), 50 deletions(-)
++
++diff --git a/tools/v8_gypfiles/toolchain.gypi b/tools/v8_gypfiles/toolchain.gypi
++index 264b3e478e..0b41848145 100644
++--- a/tools/v8_gypfiles/toolchain.gypi
+++++ b/tools/v8_gypfiles/toolchain.gypi
++@@ -211,31 +211,7 @@
++         'target_conditions': [
++           ['_toolset=="host"', {
++             'conditions': [
++-              ['v8_target_arch==host_arch', {
++-                # Host built with an Arm CXX compiler.
++-                'conditions': [
++-                  [ 'arm_version==7', {
++-                    'cflags': ['-march=armv7-a',],
++-                  }],
++-                  [ 'arm_version==7 or arm_version=="default"', {
++-                    'conditions': [
++-                      [ 'arm_fpu!="default"', {
++-                        'cflags': ['-mfpu=<(arm_fpu)',],
++-                      }],
++-                    ],
++-                  }],
++-                  [ 'arm_float_abi!="default"', {
++-                    'cflags': ['-mfloat-abi=<(arm_float_abi)',],
++-                  }],
++-                  [ 'arm_thumb==1', {
++-                    'cflags': ['-mthumb',],
++-                  }],
++-                  [ 'arm_thumb==0', {
++-                    'cflags': ['-marm',],
++-                  }],
++-                ],
++-              }, {
++-                # 'v8_target_arch!=host_arch'
+++              ['v8_target_arch!=host_arch', {
++                 # Host not built with an Arm CXX compiler (simulator build).
++                 'conditions': [
++                   [ 'arm_float_abi=="hard"', {
++@@ -254,31 +230,7 @@
++           }],  # _toolset=="host"
++           ['_toolset=="target"', {
++             'conditions': [
++-              ['v8_target_arch==target_arch', {
++-                # Target built with an Arm CXX compiler.
++-                'conditions': [
++-                  [ 'arm_version==7', {
++-                    'cflags': ['-march=armv7-a',],
++-                  }],
++-                  [ 'arm_version==7 or arm_version=="default"', {
++-                    'conditions': [
++-                      [ 'arm_fpu!="default"', {
++-                        'cflags': ['-mfpu=<(arm_fpu)',],
++-                      }],
++-                    ],
++-                  }],
++-                  [ 'arm_float_abi!="default"', {
++-                    'cflags': ['-mfloat-abi=<(arm_float_abi)',],
++-                  }],
++-                  [ 'arm_thumb==1', {
++-                    'cflags': ['-mthumb',],
++-                  }],
++-                  [ 'arm_thumb==0', {
++-                    'cflags': ['-marm',],
++-                  }],
++-                ],
++-              }, {
++-                # 'v8_target_arch!=target_arch'
+++              ['v8_target_arch!=target_arch', {
++                 # Target not built with an Arm CXX compiler (simulator build).
++                 'conditions': [
++                   [ 'arm_float_abi=="hard"', {
++-- 
++2.20.1
++
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/big-endian.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/big-endian.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/big-endian.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/big-endian.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,18 @@
++
++https://github.com/v8/v8/commit/878ccb33bd3cf0e6dc018ff8d15843f585ac07be
++
++did some automated cleanups but it missed big-endian code.
++
++Upstream-Status: Pending
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++--- a/deps/v8/src/runtime/runtime-utils.h
+++++ b/deps/v8/src/runtime/runtime-utils.h
++@@ -126,7 +126,7 @@ static inline ObjectPair MakePair(Object
++ #if defined(V8_TARGET_LITTLE_ENDIAN)
++   return x.ptr() | (static_cast<ObjectPair>(y.ptr()) << 32);
++ #elif defined(V8_TARGET_BIG_ENDIAN)
++-  return y->ptr() | (static_cast<ObjectPair>(x->ptr()) << 32);
+++  return y.ptr() | (static_cast<ObjectPair>(x.ptr()) << 32);
++ #else
++ #error Unknown endianness
++ #endif
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/CVE-2022-32212.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/CVE-2022-32212.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/CVE-2022-32212.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/CVE-2022-32212.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,133 @@
++commit 48c5aa5cab718d04473fa2761d532657c84b8131
++Author: Tobias Nießen <tniessen@tnie.de>
++Date:   Fri May 27 21:18:49 2022 +0000
++
++    src: fix IPv4 validation in inspector_socket
++
++    Co-authored-by: RafaelGSS <rafael.nunu@hotmail.com>
++    PR-URL: https://github.com/nodejs-private/node-private/pull/320
++    Backport-PR-URL: https://github.com/nodejs-private/node-private/pull/325
++    Reviewed-By: Matteo Collina <matteo.collina@gmail.com>
++    Reviewed-By: RafaelGSS <rafael.nunu@hotmail.com>
++    CVE-ID: CVE-2022-32212
++
++CVE: CVE-2022-32212
++Upstream-Status: Backport [https://sources.debian.org/src/nodejs/12.22.12~dfsg-1~deb11u3/debian/patches/cve-2022-32212.patch]
++Comment: No hunks refreshed
++Signed-off-by: Poonam Jadhav <Poonam.Jadhav@kpit.com>
++
++Index: nodejs-12.22.12~dfsg/src/inspector_socket.cc
++===================================================================
++--- nodejs-12.22.12~dfsg.orig/src/inspector_socket.cc
+++++ nodejs-12.22.12~dfsg/src/inspector_socket.cc
++@@ -168,14 +168,22 @@ static std::string TrimPort(const std::s
++ static bool IsIPAddress(const std::string& host) {
++   if (host.length() >= 4 && host.front() == '[' && host.back() == ']')
++     return true;
++-  int quads = 0;
+++  uint_fast16_t accum = 0;
+++  uint_fast8_t quads = 0;
+++  bool empty = true;
+++  auto endOctet = [&accum, &quads, &empty](bool final = false) {
+++    return !empty && accum <= 0xff && ++quads <= 4 && final == (quads == 4) &&
+++           (empty = true) && !(accum = 0);
+++  };
++   for (char c : host) {
++-    if (c == '.')
++-      quads++;
++-    else if (!isdigit(c))
+++    if (isdigit(c)) {
+++      if ((accum = (accum * 10) + (c - '0')) > 0xff) return false;
+++      empty = false;
+++    } else if (c != '.' || !endOctet()) {
++       return false;
+++    }
++   }
++-  return quads == 3;
+++  return endOctet(true);
++ }
++ 
++ // Constants for hybi-10 frame format.
++Index: nodejs-12.22.12~dfsg/test/cctest/test_inspector_socket.cc
++===================================================================
++--- nodejs-12.22.12~dfsg.orig/test/cctest/test_inspector_socket.cc
+++++ nodejs-12.22.12~dfsg/test/cctest/test_inspector_socket.cc
++@@ -851,4 +851,78 @@ TEST_F(InspectorSocketTest, HostCheckedF
++   expect_failure_no_delegate(UPGRADE_REQUEST);
++ }
++ 
+++TEST_F(InspectorSocketTest, HostIPChecked) {
+++  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+++                                              "Host: 10.0.2.555:9229\r\n\r\n";
+++  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+++                 INVALID_HOST_IP_REQUEST.length());
+++  expect_handshake_failure();
+++}
+++
+++TEST_F(InspectorSocketTest, HostNegativeIPChecked) {
+++  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+++                                              "Host: 10.0.-23.255:9229\r\n\r\n";
+++  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+++                 INVALID_HOST_IP_REQUEST.length());
+++  expect_handshake_failure();
+++}
+++
+++TEST_F(InspectorSocketTest, HostIpOctetOutOfIntRangeChecked) {
+++  const std::string INVALID_HOST_IP_REQUEST =
+++      "GET /json HTTP/1.1\r\n"
+++      "Host: 127.0.0.4294967296:9229\r\n\r\n";
+++  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+++                 INVALID_HOST_IP_REQUEST.length());
+++  expect_handshake_failure();
+++}
+++
+++TEST_F(InspectorSocketTest, HostIpOctetFarOutOfIntRangeChecked) {
+++  const std::string INVALID_HOST_IP_REQUEST =
+++      "GET /json HTTP/1.1\r\n"
+++      "Host: 127.0.0.18446744073709552000:9229\r\n\r\n";
+++  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+++                 INVALID_HOST_IP_REQUEST.length());
+++  expect_handshake_failure();
+++}
+++
+++TEST_F(InspectorSocketTest, HostIpEmptyOctetStartChecked) {
+++  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+++                                              "Host: .0.0.1:9229\r\n\r\n";
+++  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+++                 INVALID_HOST_IP_REQUEST.length());
+++  expect_handshake_failure();
+++}
+++
+++TEST_F(InspectorSocketTest, HostIpEmptyOctetMidChecked) {
+++  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+++                                              "Host: 127..0.1:9229\r\n\r\n";
+++  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+++                 INVALID_HOST_IP_REQUEST.length());
+++  expect_handshake_failure();
+++}
+++
+++TEST_F(InspectorSocketTest, HostIpEmptyOctetEndChecked) {
+++  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+++                                              "Host: 127.0.0.:9229\r\n\r\n";
+++  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+++                 INVALID_HOST_IP_REQUEST.length());
+++  expect_handshake_failure();
+++}
+++
+++TEST_F(InspectorSocketTest, HostIpTooFewOctetsChecked) {
+++  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+++                                              "Host: 127.0.1:9229\r\n\r\n";
+++  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+++                 INVALID_HOST_IP_REQUEST.length());
+++  expect_handshake_failure();
+++}
+++
+++TEST_F(InspectorSocketTest, HostIpTooManyOctetsChecked) {
+++  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+++                                              "Host: 127.0.0.0.1:9229\r\n\r\n";
+++  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+++                 INVALID_HOST_IP_REQUEST.length());
+++  expect_handshake_failure();
+++}
+++
++ }  // anonymous namespace
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/CVE-2022-35255.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/CVE-2022-35255.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/CVE-2022-35255.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/CVE-2022-35255.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,237 @@
++Origin: https://github.com/nodejs/node/commit/0c2a5723beff39d1f62daec96b5389da3d427e79
++Reviewed-by: Aron Xu <aron@debian.org>
++Last-Update: 2022-01-05
++Comment:
++  Although WebCrypto is not implemented in 12.x series, this fix is introducing
++  enhancment to the crypto setup of V8:EntropySource().
++
++commit 0c2a5723beff39d1f62daec96b5389da3d427e79
++Author: Ben Noordhuis <info@bnoordhuis.nl>
++Date:   Sun Sep 11 10:48:34 2022 +0200
++
++    crypto: fix weak randomness in WebCrypto keygen
++    
++    Commit dae283d96f from August 2020 introduced a call to EntropySource()
++    in SecretKeyGenTraits::DoKeyGen() in src/crypto/crypto_keygen.cc. There
++    are two problems with that:
++    
++    1. It does not check the return value, it assumes EntropySource() always
++       succeeds, but it can (and sometimes will) fail.
++    
++    2. The random data returned byEntropySource() may not be
++       cryptographically strong and therefore not suitable as keying
++       material.
++    
++    An example is a freshly booted system or a system without /dev/random or
++    getrandom(2).
++    
++    EntropySource() calls out to openssl's RAND_poll() and RAND_bytes() in a
++    best-effort attempt to obtain random data. OpenSSL has a built-in CSPRNG
++    but that can fail to initialize, in which case it's possible either:
++    
++    1. No random data gets written to the output buffer, i.e., the output is
++       unmodified, or
++    
++    2. Weak random data is written. It's theoretically possible for the
++       output to be fully predictable because the CSPRNG starts from a
++       predictable state.
++    
++    Replace EntropySource() and CheckEntropy() with new function CSPRNG()
++    that enforces checking of the return value. Abort on startup when the
++    entropy pool fails to initialize because that makes it too easy to
++    compromise the security of the process.
++    
++    Refs: https://hackerone.com/bugs?report_id=1690000
++    Refs: https://github.com/nodejs/node/pull/35093
++    
++    Reviewed-By: Rafael Gonzaga <rafael.nunu@hotmail.com>
++    Reviewed-By: Tobias Nießen <tniessen@tnie.de>
++    PR-URL: #346
++    Backport-PR-URL: #351
++    CVE-ID: CVE-2022-35255
++
++CVE: CVE-2022-35255
++Upstream-Status: Backport [https://sources.debian.org/src/nodejs/12.22.12~dfsg-1~deb11u3/debian/patches/cve-2022-35255.patch]
++Comment: No hunks refreshed
++Signed-off-by: Poonam Jadhav <Poonam.Jadhav@kpit.com>
++
++Index: nodejs-12.22.12~dfsg/node.gyp
++===================================================================
++--- nodejs-12.22.12~dfsg.orig/node.gyp
+++++ nodejs-12.22.12~dfsg/node.gyp
++@@ -743,6 +743,8 @@
++         'openssl_default_cipher_list%': '',
++       },
++ 
+++      'cflags': ['-Werror=unused-result'],
+++
++       'defines': [
++         'NODE_ARCH="<(target_arch)"',
++         'NODE_PLATFORM="<(OS)"',
++Index: nodejs-12.22.12~dfsg/src/node_crypto.cc
++===================================================================
++--- nodejs-12.22.12~dfsg.orig/src/node_crypto.cc
+++++ nodejs-12.22.12~dfsg/src/node_crypto.cc
++@@ -386,48 +386,14 @@ void ThrowCryptoError(Environment* env,
++   env->isolate()->ThrowException(exception);
++ }
++ 
+++MUST_USE_RESULT CSPRNGResult CSPRNG(void* buffer, size_t length) {
+++  do {
+++    if (1 == RAND_status())
+++      if (1 == RAND_bytes(static_cast<unsigned char*>(buffer), length))
+++        return {true};
+++  } while (1 == RAND_poll());
++ 
++-// Ensure that OpenSSL has enough entropy (at least 256 bits) for its PRNG.
++-// The entropy pool starts out empty and needs to fill up before the PRNG
++-// can be used securely.  Once the pool is filled, it never dries up again;
++-// its contents is stirred and reused when necessary.
++-//
++-// OpenSSL normally fills the pool automatically but not when someone starts
++-// generating random numbers before the pool is full: in that case OpenSSL
++-// keeps lowering the entropy estimate to thwart attackers trying to guess
++-// the initial state of the PRNG.
++-//
++-// When that happens, we will have to wait until enough entropy is available.
++-// That should normally never take longer than a few milliseconds.
++-//
++-// OpenSSL draws from /dev/random and /dev/urandom.  While /dev/random may
++-// block pending "true" randomness, /dev/urandom is a CSPRNG that doesn't
++-// block under normal circumstances.
++-//
++-// The only time when /dev/urandom may conceivably block is right after boot,
++-// when the whole system is still low on entropy.  That's not something we can
++-// do anything about.
++-inline void CheckEntropy() {
++-  for (;;) {
++-    int status = RAND_status();
++-    CHECK_GE(status, 0);  // Cannot fail.
++-    if (status != 0)
++-      break;
++-
++-    // Give up, RAND_poll() not supported.
++-    if (RAND_poll() == 0)
++-      break;
++-  }
++-}
++-
++-
++-bool EntropySource(unsigned char* buffer, size_t length) {
++-  // Ensure that OpenSSL's PRNG is properly seeded.
++-  CheckEntropy();
++-  // RAND_bytes() can return 0 to indicate that the entropy data is not truly
++-  // random. That's okay, it's still better than V8's stock source of entropy,
++-  // which is /dev/urandom on UNIX platforms and the current time on Windows.
++-  return RAND_bytes(buffer, length) != -1;
+++  return {false};
++ }
++ 
++ void SecureContext::Initialize(Environment* env, Local<Object> target) {
++@@ -649,9 +615,9 @@ void SecureContext::Init(const FunctionC
++   // OpenSSL 1.1.0 changed the ticket key size, but the OpenSSL 1.0.x size was
++   // exposed in the public API. To retain compatibility, install a callback
++   // which restores the old algorithm.
++-  if (RAND_bytes(sc->ticket_key_name_, sizeof(sc->ticket_key_name_)) <= 0 ||
++-      RAND_bytes(sc->ticket_key_hmac_, sizeof(sc->ticket_key_hmac_)) <= 0 ||
++-      RAND_bytes(sc->ticket_key_aes_, sizeof(sc->ticket_key_aes_)) <= 0) {
+++  if (CSPRNG(sc->ticket_key_name_, sizeof(sc->ticket_key_name_)).is_err() ||
+++      CSPRNG(sc->ticket_key_hmac_, sizeof(sc->ticket_key_hmac_)).is_err() ||
+++      CSPRNG(sc->ticket_key_aes_, sizeof(sc->ticket_key_aes_)).is_err()) {
++     return env->ThrowError("Error generating ticket keys");
++   }
++   SSL_CTX_set_tlsext_ticket_key_cb(sc->ctx_.get(), TicketCompatibilityCallback);
++@@ -1643,7 +1609,7 @@ int SecureContext::TicketCompatibilityCa
++ 
++   if (enc) {
++     memcpy(name, sc->ticket_key_name_, sizeof(sc->ticket_key_name_));
++-    if (RAND_bytes(iv, 16) <= 0 ||
+++    if (CSPRNG(iv, 16).is_err() ||
++         EVP_EncryptInit_ex(ectx, EVP_aes_128_cbc(), nullptr,
++                            sc->ticket_key_aes_, iv) <= 0 ||
++         HMAC_Init_ex(hctx, sc->ticket_key_hmac_, sizeof(sc->ticket_key_hmac_),
++@@ -5867,8 +5833,7 @@ struct RandomBytesJob : public CryptoJob
++       : CryptoJob(env), rc(Nothing<int>()) {}
++ 
++   inline void DoThreadPoolWork() override {
++-    CheckEntropy();  // Ensure that OpenSSL's PRNG is properly seeded.
++-    rc = Just(RAND_bytes(data, size));
+++    rc = Just(int(CSPRNG(data, size).is_ok()));
++     if (0 == rc.FromJust()) errors.Capture();
++   }
++ 
++@@ -6318,8 +6283,8 @@ class GenerateKeyPairJob : public Crypto
++   }
++ 
++   inline bool GenerateKey() {
++-    // Make sure that the CSPRNG is properly seeded so the results are secure.
++-    CheckEntropy();
+++    // Make sure that the CSPRNG is properly seeded.
+++    CHECK(CSPRNG(nullptr, 0).is_ok());
++ 
++     // Create the key generation context.
++     EVPKeyCtxPointer ctx = config_->Setup();
++Index: nodejs-12.22.12~dfsg/src/node_crypto.h
++===================================================================
++--- nodejs-12.22.12~dfsg.orig/src/node_crypto.h
+++++ nodejs-12.22.12~dfsg/src/node_crypto.h
++@@ -840,7 +840,19 @@ class ECDH final : public BaseObject {
++   const EC_GROUP* group_;
++ };
++ 
++-bool EntropySource(unsigned char* buffer, size_t length);
+++struct CSPRNGResult {
+++  const bool ok;
+++  MUST_USE_RESULT bool is_ok() const { return ok; }
+++  MUST_USE_RESULT bool is_err() const { return !ok; }
+++};
+++
+++// Either succeeds with exactly |length| bytes of cryptographically
+++// strong pseudo-random data, or fails. This function may block.
+++// Don't assume anything about the contents of |buffer| on error.
+++// As a special case, |length == 0| can be used to check if the CSPRNG
+++// is properly seeded without consuming entropy.
+++MUST_USE_RESULT CSPRNGResult CSPRNG(void* buffer, size_t length);
+++
++ #ifndef OPENSSL_NO_ENGINE
++ void SetEngine(const v8::FunctionCallbackInfo<v8::Value>& args);
++ #endif  // !OPENSSL_NO_ENGINE
++Index: nodejs-12.22.12~dfsg/src/inspector_io.cc
++===================================================================
++--- nodejs-12.22.12~dfsg.orig/src/inspector_io.cc
+++++ nodejs-12.22.12~dfsg/src/inspector_io.cc
++@@ -46,8 +46,7 @@ std::string ScriptPath(uv_loop_t* loop,
++ // Used ver 4 - with numbers
++ std::string GenerateID() {
++   uint16_t buffer[8];
++-  CHECK(crypto::EntropySource(reinterpret_cast<unsigned char*>(buffer),
++-                              sizeof(buffer)));
+++  CHECK(crypto::CSPRNG(buffer, sizeof(buffer)).is_ok());
++ 
++   char uuid[256];
++   snprintf(uuid, sizeof(uuid), "%04x%04x-%04x-%04x-%04x-%04x%04x%04x",
++Index: nodejs-12.22.12~dfsg/src/node.cc
++===================================================================
++--- nodejs-12.22.12~dfsg.orig/src/node.cc
+++++ nodejs-12.22.12~dfsg/src/node.cc
++@@ -969,9 +969,17 @@ InitializationResult InitializeOncePerPr
++   // the random source is properly initialized first.
++   OPENSSL_init();
++ #endif  // NODE_FIPS_MODE
++-  // V8 on Windows doesn't have a good source of entropy. Seed it from
++-  // OpenSSL's pool.
++-  V8::SetEntropySource(crypto::EntropySource);
+++  // Ensure CSPRNG is properly seeded.
+++  CHECK(crypto::CSPRNG(nullptr, 0).is_ok());
+++
+++  V8::SetEntropySource([](unsigned char* buffer, size_t length) {
+++    // V8 falls back to very weak entropy when this function fails
+++    // and /dev/urandom isn't available. That wouldn't be so bad if
+++    // the entropy was only used for Math.random() but it's also used for
+++    // hash table and address space layout randomization. Better to abort.
+++    CHECK(crypto::CSPRNG(buffer, length).is_ok());
+++    return true;
+++    });
++ #endif  // HAVE_OPENSSL
++ 
++   per_process::v8_platform.Initialize(
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/CVE-2022-43548.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/CVE-2022-43548.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/CVE-2022-43548.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/CVE-2022-43548.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,214 @@
++commit 2b433af094fb79cf80f086038b7f36342cb6826f
++Author: Tobias Nießen <tniessen@tnie.de>
++Date:   Sun Sep 25 12:34:05 2022 +0000
++
++    inspector: harden IP address validation again
++    
++    Use inet_pton() to parse IP addresses, which restricts IP addresses
++    to a small number of well-defined formats. In particular, octal and
++    hexadecimal number formats are not allowed, and neither are leading
++    zeros. Also explicitly reject 0.0.0.0/8 and ::/128 as non-routable.
++    
++    Refs: https://hackerone.com/reports/1710652
++    CVE-ID: CVE-2022-43548
++    PR-URL: https://github.com/nodejs-private/node-private/pull/354
++    Reviewed-by: Michael Dawson <midawson@redhat.com>
++    Reviewed-by: Rafael Gonzaga <rafael.nunu@hotmail.com>
++    Reviewed-by: Rich Trott <rtrott@gmail.com>
++
++CVE: CVE-2022-43548
++Upstream-Status: Backport [https://sources.debian.org/src/nodejs/12.22.12~dfsg-1~deb11u3/debian/patches/cve-2022-43548.patch]
++Comment: No hunks refreshed
++Signed-off-by: Poonam Jadhav <Poonam.Jadhav@kpit.com>
++
++Index: nodejs-12.22.12~dfsg/src/inspector_socket.cc
++===================================================================
++--- nodejs-12.22.12~dfsg.orig/src/inspector_socket.cc
+++++ nodejs-12.22.12~dfsg/src/inspector_socket.cc
++@@ -10,6 +10,7 @@
++ 
++ #include "openssl/sha.h"  // Sha-1 hash
++ 
+++#include <algorithm>
++ #include <cstring>
++ #include <map>
++ 
++@@ -166,25 +167,71 @@ static std::string TrimPort(const std::s
++ }
++ 
++ static bool IsIPAddress(const std::string& host) {
++-  if (host.length() >= 4 && host.front() == '[' && host.back() == ']')
+++  // TODO(tniessen): add CVEs to the following bullet points
+++  // To avoid DNS rebinding attacks, we are aware of the following requirements:
+++  // * the host name must be an IP address,
+++  // * the IP address must be routable, and
+++  // * the IP address must be formatted unambiguously.
+++
+++  // The logic below assumes that the string is null-terminated, so ensure that
+++  // we did not somehow end up with null characters within the string.
+++  if (host.find('\0') != std::string::npos) return false;
+++
+++  // All IPv6 addresses must be enclosed in square brackets, and anything
+++  // enclosed in square brackets must be an IPv6 address.
+++  if (host.length() >= 4 && host.front() == '[' && host.back() == ']') {
+++    // INET6_ADDRSTRLEN is the maximum length of the dual format (including the
+++    // terminating null character), which is the longest possible representation
+++    // of an IPv6 address: xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:ddd.ddd.ddd.ddd
+++    if (host.length() - 2 >= INET6_ADDRSTRLEN) return false;
+++
+++    // Annoyingly, libuv's implementation of inet_pton() deviates from other
+++    // implementations of the function in that it allows '%' in IPv6 addresses.
+++    if (host.find('%') != std::string::npos) return false;
+++
+++    // Parse the IPv6 address to ensure it is syntactically valid.
+++    char ipv6_str[INET6_ADDRSTRLEN];
+++    std::copy(host.begin() + 1, host.end() - 1, ipv6_str);
+++    ipv6_str[host.length()] = '\0';
+++    unsigned char ipv6[sizeof(struct in6_addr)];
+++    if (uv_inet_pton(AF_INET6, ipv6_str, ipv6) != 0) return false;
+++
+++    // The only non-routable IPv6 address is ::/128. It should not be necessary
+++    // to explicitly reject it because it will still be enclosed in square
+++    // brackets and not even macOS should make DNS requests in that case, but
+++    // history has taught us that we cannot be careful enough.
+++    // Note that RFC 4291 defines both "IPv4-Compatible IPv6 Addresses" and
+++    // "IPv4-Mapped IPv6 Addresses", which means that there are IPv6 addresses
+++    // (other than ::/128) that represent non-routable IPv4 addresses. However,
+++    // this translation assumes that the host is interpreted as an IPv6 address
+++    // in the first place, at which point DNS rebinding should not be an issue.
+++    if (std::all_of(ipv6, ipv6 + sizeof(ipv6), [](auto b) { return b == 0; })) {
+++       return false;
+++     }
+++
+++    // It is a syntactically valid and routable IPv6 address enclosed in square
+++    // brackets. No client should be able to misinterpret this.
++     return true;
++-  uint_fast16_t accum = 0;
++-  uint_fast8_t quads = 0;
++-  bool empty = true;
++-  auto endOctet = [&accum, &quads, &empty](bool final = false) {
++-    return !empty && accum <= 0xff && ++quads <= 4 && final == (quads == 4) &&
++-           (empty = true) && !(accum = 0);
++-  };
++-  for (char c : host) {
++-    if (isdigit(c)) {
++-      if ((accum = (accum * 10) + (c - '0')) > 0xff) return false;
++-      empty = false;
++-    } else if (c != '.' || !endOctet()) {
++-      return false;
++-    }
++-  }
++-  return endOctet(true);
++-}
+++   }
+++
+++  // Anything not enclosed in square brackets must be an IPv4 address. It is
+++  // important here that inet_pton() accepts only the so-called dotted-decimal
+++  // notation, which is a strict subset of the so-called numbers-and-dots
+++  // notation that is allowed by inet_aton() and inet_addr(). This subset does
+++  // not allow hexadecimal or octal number formats.
+++  unsigned char ipv4[sizeof(struct in_addr)];
+++  if (uv_inet_pton(AF_INET, host.c_str(), ipv4) != 0) return false;
+++
+++  // The only strictly non-routable IPv4 address is 0.0.0.0, and macOS will make
+++  // DNS requests for this IP address, so we need to explicitly reject it. In
+++  // fact, we can safely reject all of 0.0.0.0/8 (see Section 3.2 of RFC 791 and
+++  // Section 3.2.1.3 of RFC 1122).
+++  // Note that inet_pton() stores the IPv4 address in network byte order.
+++  if (ipv4[0] == 0) return false;
+++
+++  // It is a routable IPv4 address in dotted-decimal notation.
+++  return true;
+++ }
++ 
++ // Constants for hybi-10 frame format.
++ 
++Index: nodejs-12.22.12~dfsg/test/cctest/test_inspector_socket.cc
++===================================================================
++--- nodejs-12.22.12~dfsg.orig/test/cctest/test_inspector_socket.cc
+++++ nodejs-12.22.12~dfsg/test/cctest/test_inspector_socket.cc
++@@ -925,4 +925,84 @@ TEST_F(InspectorSocketTest, HostIpTooMan
++   expect_handshake_failure();
++ }
++ 
+++TEST_F(InspectorSocketTest, HostIpInvalidOctalOctetStartChecked) {
+++  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+++                                              "Host: 08.1.1.1:9229\r\n\r\n";
+++  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+++                 INVALID_HOST_IP_REQUEST.length());
+++  expect_handshake_failure();
+++}
+++
+++TEST_F(InspectorSocketTest, HostIpInvalidOctalOctetMidChecked) {
+++  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+++                                              "Host: 1.09.1.1:9229\r\n\r\n";
+++  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+++                 INVALID_HOST_IP_REQUEST.length());
+++  expect_handshake_failure();
+++}
+++
+++TEST_F(InspectorSocketTest, HostIpInvalidOctalOctetEndChecked) {
+++  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+++                                              "Host: 1.1.1.009:9229\r\n\r\n";
+++  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+++                 INVALID_HOST_IP_REQUEST.length());
+++  expect_handshake_failure();
+++}
+++
+++TEST_F(InspectorSocketTest, HostIpLeadingZeroStartChecked) {
+++  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+++                                              "Host: 01.1.1.1:9229\r\n\r\n";
+++  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+++                 INVALID_HOST_IP_REQUEST.length());
+++  expect_handshake_failure();
+++}
+++
+++TEST_F(InspectorSocketTest, HostIpLeadingZeroMidChecked) {
+++  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+++                                              "Host: 1.1.001.1:9229\r\n\r\n";
+++  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+++                 INVALID_HOST_IP_REQUEST.length());
+++  expect_handshake_failure();
+++}
+++
+++TEST_F(InspectorSocketTest, HostIpLeadingZeroEndChecked) {
+++  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+++                                              "Host: 1.1.1.01:9229\r\n\r\n";
+++  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+++                 INVALID_HOST_IP_REQUEST.length());
+++  expect_handshake_failure();
+++}
+++
+++TEST_F(InspectorSocketTest, HostIPv6NonRoutable) {
+++  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+++                                              "Host: [::]:9229\r\n\r\n";
+++  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+++                 INVALID_HOST_IP_REQUEST.length());
+++  expect_handshake_failure();
+++}
+++
+++TEST_F(InspectorSocketTest, HostIPv6NonRoutableDual) {
+++  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+++                                              "Host: [::0.0.0.0]:9229\r\n\r\n";
+++  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+++                 INVALID_HOST_IP_REQUEST.length());
+++  expect_handshake_failure();
+++}
+++
+++TEST_F(InspectorSocketTest, HostIPv4InSquareBrackets) {
+++  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+++                                              "Host: [127.0.0.1]:9229\r\n\r\n";
+++  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+++                 INVALID_HOST_IP_REQUEST.length());
+++  expect_handshake_failure();
+++}
+++
+++TEST_F(InspectorSocketTest, HostIPv6InvalidAbbreviation) {
+++  const std::string INVALID_HOST_IP_REQUEST = "GET /json HTTP/1.1\r\n"
+++                                              "Host: [:::1]:9229\r\n\r\n";
+++  send_in_chunks(INVALID_HOST_IP_REQUEST.c_str(),
+++                 INVALID_HOST_IP_REQUEST.length());
+++  expect_handshake_failure();
+++}
+++
++ }  // anonymous namespace
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/CVE-llhttp.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/CVE-llhttp.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/CVE-llhttp.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/CVE-llhttp.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,4348 @@
++Reviewed-by: Aron Xu <aron@debian.org>
++Last-Update: 2023-01-05
++Comment:
++  This patch updates the embeded copy of llhttp from version 2.1.4 to 2.1.6,
++  which is upstream's actual fix for CVE-2022-32213, CVE-2022-32214, CVE-2022-32215,
++  CVE-2022-35256.
++  Test cases are ported to use mustCall() to replace the later introduced
++  mustSucceed(), to avoid pulling in too many dependent new test codes.
++References:
++  * https://github.com/nodejs/node/commit/da0fda0fe81d372e24c0cb11aec37534985708dd
++  * https://github.com/nodejs/node/commit/a9f1146b8827855e342834458a71f2367346ace0
++
++CVE: CVE-2022-32213 CVE-2022-32214 CVE-2022-32215 CVE-2022-35256
++Upstream-Status: Backport [https://sources.debian.org/src/nodejs/12.22.12~dfsg-1~deb11u3/debian/patches/cve-llhttp.patch]
++Comment: No hunks refreshed
++Signed-off-by: Poonam Jadhav <Poonam.Jadhav@kpit.com>
++
++--- nodejs-12.22.12~dfsg/deps/llhttp/include/llhttp.h
+++++ nodejs-12.22.12~dfsg/deps/llhttp/include/llhttp.h
++@@ -3,7 +3,7 @@
++ 
++ #define LLHTTP_VERSION_MAJOR 2
++ #define LLHTTP_VERSION_MINOR 1
++-#define LLHTTP_VERSION_PATCH 4
+++#define LLHTTP_VERSION_PATCH 6
++ 
++ #ifndef LLHTTP_STRICT_MODE
++ # define LLHTTP_STRICT_MODE 0
++@@ -58,6 +58,7 @@
++   HPE_OK = 0,
++   HPE_INTERNAL = 1,
++   HPE_STRICT = 2,
+++  HPE_CR_EXPECTED = 25,
++   HPE_LF_EXPECTED = 3,
++   HPE_UNEXPECTED_CONTENT_LENGTH = 4,
++   HPE_CLOSED_CONNECTION = 5,
++@@ -78,7 +79,7 @@
++   HPE_CB_CHUNK_COMPLETE = 20,
++   HPE_PAUSED = 21,
++   HPE_PAUSED_UPGRADE = 22,
++-  HPE_USER = 23
+++  HPE_USER = 24
++ };
++ typedef enum llhttp_errno llhttp_errno_t;
++ 
++@@ -153,6 +154,7 @@
++   XX(0, OK, OK) \
++   XX(1, INTERNAL, INTERNAL) \
++   XX(2, STRICT, STRICT) \
+++  XX(25, CR_EXPECTED, CR_EXPECTED) \
++   XX(3, LF_EXPECTED, LF_EXPECTED) \
++   XX(4, UNEXPECTED_CONTENT_LENGTH, UNEXPECTED_CONTENT_LENGTH) \
++   XX(5, CLOSED_CONNECTION, CLOSED_CONNECTION) \
++@@ -173,7 +175,7 @@
++   XX(20, CB_CHUNK_COMPLETE, CB_CHUNK_COMPLETE) \
++   XX(21, PAUSED, PAUSED) \
++   XX(22, PAUSED_UPGRADE, PAUSED_UPGRADE) \
++-  XX(23, USER, USER) \
+++  XX(24, USER, USER) \
++ 
++ 
++ #define HTTP_METHOD_MAP(XX) \
++--- nodejs-12.22.12~dfsg/deps/llhttp/src/llhttp.c
+++++ nodejs-12.22.12~dfsg/deps/llhttp/src/llhttp.c
++@@ -325,6 +325,7 @@
++   s_n_llhttp__internal__n_header_value_lws,
++   s_n_llhttp__internal__n_header_value_almost_done,
++   s_n_llhttp__internal__n_header_value_lenient,
+++  s_n_llhttp__internal__n_error_25,
++   s_n_llhttp__internal__n_header_value_otherwise,
++   s_n_llhttp__internal__n_header_value_connection_token,
++   s_n_llhttp__internal__n_header_value_connection_ws,
++@@ -332,14 +333,16 @@
++   s_n_llhttp__internal__n_header_value_connection_2,
++   s_n_llhttp__internal__n_header_value_connection_3,
++   s_n_llhttp__internal__n_header_value_connection,
++-  s_n_llhttp__internal__n_error_26,
++   s_n_llhttp__internal__n_error_27,
+++  s_n_llhttp__internal__n_error_28,
++   s_n_llhttp__internal__n_header_value_content_length_ws,
++   s_n_llhttp__internal__n_header_value_content_length,
++-  s_n_llhttp__internal__n_header_value_te_chunked_last,
+++  s_n_llhttp__internal__n_error_30,
+++  s_n_llhttp__internal__n_error_29,
++   s_n_llhttp__internal__n_header_value_te_token_ows,
++   s_n_llhttp__internal__n_header_value,
++   s_n_llhttp__internal__n_header_value_te_token,
+++  s_n_llhttp__internal__n_header_value_te_chunked_last,
++   s_n_llhttp__internal__n_header_value_te_chunked,
++   s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1,
++   s_n_llhttp__internal__n_header_value_discard_ws,
++@@ -734,7 +737,7 @@
++   return 0;
++ }
++ 
++-int llhttp__internal__c_update_header_state_2(
+++int llhttp__internal__c_update_header_state_3(
++     llhttp__internal_t* state,
++     const unsigned char* p,
++     const unsigned char* endp) {
++@@ -742,7 +745,7 @@
++   return 0;
++ }
++ 
++-int llhttp__internal__c_update_header_state_4(
+++int llhttp__internal__c_update_header_state_1(
++     llhttp__internal_t* state,
++     const unsigned char* p,
++     const unsigned char* endp) {
++@@ -750,7 +753,7 @@
++   return 0;
++ }
++ 
++-int llhttp__internal__c_update_header_state_5(
+++int llhttp__internal__c_update_header_state_6(
++     llhttp__internal_t* state,
++     const unsigned char* p,
++     const unsigned char* endp) {
++@@ -758,7 +761,7 @@
++   return 0;
++ }
++ 
++-int llhttp__internal__c_update_header_state_6(
+++int llhttp__internal__c_update_header_state_7(
++     llhttp__internal_t* state,
++     const unsigned char* p,
++     const unsigned char* endp) {
++@@ -766,7 +769,7 @@
++   return 0;
++ }
++ 
++-int llhttp__internal__c_test_flags_6(
+++int llhttp__internal__c_test_flags_7(
++     llhttp__internal_t* state,
++     const unsigned char* p,
++     const unsigned char* endp) {
++@@ -807,6 +810,13 @@
++   return 0;
++ }
++ 
+++int llhttp__internal__c_test_flags_8(
+++    llhttp__internal_t* state,
+++    const unsigned char* p,
+++    const unsigned char* endp) {
+++  return (state->flags & 8) == 8;
+++}
+++
++ int llhttp__internal__c_or_flags_16(
++     llhttp__internal_t* state,
++     const unsigned char* p,
++@@ -823,7 +833,7 @@
++   return 0;
++ }
++ 
++-int llhttp__internal__c_update_header_state_7(
+++int llhttp__internal__c_update_header_state_8(
++     llhttp__internal_t* state,
++     const unsigned char* p,
++     const unsigned char* endp) {
++@@ -831,7 +841,7 @@
++   return 0;
++ }
++ 
++-int llhttp__internal__c_or_flags_17(
+++int llhttp__internal__c_or_flags_18(
++     llhttp__internal_t* state,
++     const unsigned char* p,
++     const unsigned char* endp) {
++@@ -1554,7 +1564,7 @@
++           goto s_n_llhttp__internal__n_header_value_discard_lws;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_22;
+++          goto s_n_llhttp__internal__n_error_23;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -1567,13 +1577,13 @@
++       }
++       switch (*p) {
++         case 9: {
++-          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+++          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
++         }
++         case ' ': {
++-          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+++          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
+++          goto s_n_llhttp__internal__n_invoke_load_header_state_4;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -1590,7 +1600,7 @@
++           goto s_n_llhttp__internal__n_header_value_lws;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_23;
+++          goto s_n_llhttp__internal__n_error_24;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -1603,10 +1613,10 @@
++       }
++       switch (*p) {
++         case 10: {
++-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
+++          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3;
++         }
++         case 13: {
++-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3;
+++          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4;
++         }
++         default: {
++           p++;
++@@ -1616,20 +1626,27 @@
++       /* UNREACHABLE */;
++       abort();
++     }
+++    case s_n_llhttp__internal__n_error_25:
+++    s_n_llhttp__internal__n_error_25: {
+++      state->error = 0xa;
+++      state->reason = "Invalid header value char";
+++      state->error_pos = (const char*) p;
+++      state->_current = (void*) (intptr_t) s_error;
+++      return s_error;
+++      /* UNREACHABLE */;
+++      abort();
+++    }
++     case s_n_llhttp__internal__n_header_value_otherwise:
++     s_n_llhttp__internal__n_header_value_otherwise: {
++       if (p == endp) {
++         return s_n_llhttp__internal__n_header_value_otherwise;
++       }
++       switch (*p) {
++-        case 10: {
++-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
++-        }
++         case 13: {
++-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2;
+++          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_invoke_test_flags_5;
+++          goto s_n_llhttp__internal__n_invoke_test_flags_6;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -1692,10 +1709,10 @@
++         }
++         case ',': {
++           p++;
++-          goto s_n_llhttp__internal__n_invoke_load_header_state_4;
+++          goto s_n_llhttp__internal__n_invoke_load_header_state_5;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_4;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_5;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -1713,7 +1730,7 @@
++       switch (match_seq.status) {
++         case kMatchComplete: {
++           p++;
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_2;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_3;
++         }
++         case kMatchPause: {
++           return s_n_llhttp__internal__n_header_value_connection_1;
++@@ -1737,7 +1754,7 @@
++       switch (match_seq.status) {
++         case kMatchComplete: {
++           p++;
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_5;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_6;
++         }
++         case kMatchPause: {
++           return s_n_llhttp__internal__n_header_value_connection_2;
++@@ -1761,7 +1778,7 @@
++       switch (match_seq.status) {
++         case kMatchComplete: {
++           p++;
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_6;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
++         }
++         case kMatchPause: {
++           return s_n_llhttp__internal__n_header_value_connection_3;
++@@ -1806,8 +1823,8 @@
++       /* UNREACHABLE */;
++       abort();
++     }
++-    case s_n_llhttp__internal__n_error_26:
++-    s_n_llhttp__internal__n_error_26: {
+++    case s_n_llhttp__internal__n_error_27:
+++    s_n_llhttp__internal__n_error_27: {
++       state->error = 0xb;
++       state->reason = "Content-Length overflow";
++       state->error_pos = (const char*) p;
++@@ -1816,8 +1833,8 @@
++       /* UNREACHABLE */;
++       abort();
++     }
++-    case s_n_llhttp__internal__n_error_27:
++-    s_n_llhttp__internal__n_error_27: {
+++    case s_n_llhttp__internal__n_error_28:
+++    s_n_llhttp__internal__n_error_28: {
++       state->error = 0xb;
++       state->reason = "Invalid character in Content-Length";
++       state->error_pos = (const char*) p;
++@@ -1843,7 +1860,7 @@
++           goto s_n_llhttp__internal__n_header_value_content_length_ws;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5;
+++          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_6;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -1912,26 +1929,23 @@
++       /* UNREACHABLE */;
++       abort();
++     }
++-    case s_n_llhttp__internal__n_header_value_te_chunked_last:
++-    s_n_llhttp__internal__n_header_value_te_chunked_last: {
++-      if (p == endp) {
++-        return s_n_llhttp__internal__n_header_value_te_chunked_last;
++-      }
++-      switch (*p) {
++-        case 10: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
++-        }
++-        case 13: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
++-        }
++-        case ' ': {
++-          p++;
++-          goto s_n_llhttp__internal__n_header_value_te_chunked_last;
++-        }
++-        default: {
++-          goto s_n_llhttp__internal__n_header_value_te_chunked;
++-        }
++-      }
+++    case s_n_llhttp__internal__n_error_30:
+++    s_n_llhttp__internal__n_error_30: {
+++      state->error = 0xf;
+++      state->reason = "Invalid `Transfer-Encoding` header value";
+++      state->error_pos = (const char*) p;
+++      state->_current = (void*) (intptr_t) s_error;
+++      return s_error;
+++      /* UNREACHABLE */;
+++      abort();
+++    }
+++    case s_n_llhttp__internal__n_error_29:
+++    s_n_llhttp__internal__n_error_29: {
+++      state->error = 0xf;
+++      state->reason = "Invalid `Transfer-Encoding` header value";
+++      state->error_pos = (const char*) p;
+++      state->_current = (void*) (intptr_t) s_error;
+++      return s_error;
++       /* UNREACHABLE */;
++       abort();
++     }
++@@ -2048,8 +2062,34 @@
++           goto s_n_llhttp__internal__n_header_value_te_token_ows;
++         }
++         default: {
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_9;
+++        }
+++      }
+++      /* UNREACHABLE */;
+++      abort();
+++    }
+++    case s_n_llhttp__internal__n_header_value_te_chunked_last:
+++    s_n_llhttp__internal__n_header_value_te_chunked_last: {
+++      if (p == endp) {
+++        return s_n_llhttp__internal__n_header_value_te_chunked_last;
+++      }
+++      switch (*p) {
+++        case 10: {
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_8;
+++        }
+++        case 13: {
++           goto s_n_llhttp__internal__n_invoke_update_header_state_8;
++         }
+++        case ' ': {
+++          p++;
+++          goto s_n_llhttp__internal__n_header_value_te_chunked_last;
+++        }
+++        case ',': {
+++          goto s_n_llhttp__internal__n_invoke_load_type_1;
+++        }
+++        default: {
+++          goto s_n_llhttp__internal__n_header_value_te_token;
+++        }
++       }
++       /* UNREACHABLE */;
++       abort();
++@@ -2101,7 +2141,7 @@
++         }
++         case 10: {
++           p++;
++-          goto s_n_llhttp__internal__n_header_value_discard_lws;
+++          goto s_n_llhttp__internal__n_invoke_test_flags_5;
++         }
++         case 13: {
++           p++;
++@@ -2128,7 +2168,7 @@
++           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_2;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_28;
+++          goto s_n_llhttp__internal__n_error_31;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2218,7 +2258,7 @@
++           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_9;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2243,7 +2283,7 @@
++           return s_n_llhttp__internal__n_header_field_3;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2268,7 +2308,7 @@
++           return s_n_llhttp__internal__n_header_field_4;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2289,7 +2329,7 @@
++           goto s_n_llhttp__internal__n_header_field_4;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2313,7 +2353,7 @@
++           return s_n_llhttp__internal__n_header_field_1;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2338,7 +2378,7 @@
++           return s_n_llhttp__internal__n_header_field_5;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2363,7 +2403,7 @@
++           return s_n_llhttp__internal__n_header_field_6;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2388,7 +2428,7 @@
++           return s_n_llhttp__internal__n_header_field_7;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2417,7 +2457,7 @@
++           goto s_n_llhttp__internal__n_header_field_7;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2508,7 +2548,7 @@
++           goto s_n_llhttp__internal__n_url_to_http_09;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_29;
+++          goto s_n_llhttp__internal__n_error_32;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2533,7 +2573,7 @@
++           goto s_n_llhttp__internal__n_url_skip_lf_to_http09_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_29;
+++          goto s_n_llhttp__internal__n_error_32;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2550,7 +2590,7 @@
++           goto s_n_llhttp__internal__n_header_field_start;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_30;
+++          goto s_n_llhttp__internal__n_error_33;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2571,7 +2611,7 @@
++           goto s_n_llhttp__internal__n_req_http_end_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_30;
+++          goto s_n_llhttp__internal__n_error_33;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2634,7 +2674,7 @@
++           goto s_n_llhttp__internal__n_invoke_store_http_minor;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_31;
+++          goto s_n_llhttp__internal__n_error_34;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2651,7 +2691,7 @@
++           goto s_n_llhttp__internal__n_req_http_minor;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_32;
+++          goto s_n_llhttp__internal__n_error_35;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2714,7 +2754,7 @@
++           goto s_n_llhttp__internal__n_invoke_store_http_major;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_33;
+++          goto s_n_llhttp__internal__n_error_36;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2738,7 +2778,7 @@
++           return s_n_llhttp__internal__n_req_http_start_1;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_35;
+++          goto s_n_llhttp__internal__n_error_38;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2762,7 +2802,7 @@
++           return s_n_llhttp__internal__n_req_http_start_2;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_35;
+++          goto s_n_llhttp__internal__n_error_38;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2787,7 +2827,7 @@
++           goto s_n_llhttp__internal__n_req_http_start_2;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_35;
+++          goto s_n_llhttp__internal__n_error_38;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2878,7 +2918,7 @@
++           goto s_n_llhttp__internal__n_url_fragment;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_36;
+++          goto s_n_llhttp__internal__n_error_39;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2939,7 +2979,7 @@
++           goto s_n_llhttp__internal__n_span_end_stub_query_3;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_37;
+++          goto s_n_llhttp__internal__n_error_40;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -2977,7 +3017,7 @@
++           goto s_n_llhttp__internal__n_url_query;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_38;
+++          goto s_n_llhttp__internal__n_error_41;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3102,10 +3142,10 @@
++         }
++         case 8: {
++           p++;
++-          goto s_n_llhttp__internal__n_error_39;
+++          goto s_n_llhttp__internal__n_error_42;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_40;
+++          goto s_n_llhttp__internal__n_error_43;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3164,7 +3204,7 @@
++           goto s_n_llhttp__internal__n_url_server_with_at;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_41;
+++          goto s_n_llhttp__internal__n_error_44;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3181,7 +3221,7 @@
++           goto s_n_llhttp__internal__n_url_server;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_43;
+++          goto s_n_llhttp__internal__n_error_46;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3199,7 +3239,7 @@
++         }
++         case 10: {
++           p++;
++-          goto s_n_llhttp__internal__n_error_42;
+++          goto s_n_llhttp__internal__n_error_45;
++         }
++         case 12: {
++           p++;
++@@ -3207,18 +3247,18 @@
++         }
++         case 13: {
++           p++;
++-          goto s_n_llhttp__internal__n_error_42;
+++          goto s_n_llhttp__internal__n_error_45;
++         }
++         case ' ': {
++           p++;
++-          goto s_n_llhttp__internal__n_error_42;
+++          goto s_n_llhttp__internal__n_error_45;
++         }
++         case '/': {
++           p++;
++           goto s_n_llhttp__internal__n_url_schema_delim_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_43;
+++          goto s_n_llhttp__internal__n_error_46;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3264,7 +3304,7 @@
++         }
++         case 2: {
++           p++;
++-          goto s_n_llhttp__internal__n_error_42;
+++          goto s_n_llhttp__internal__n_error_45;
++         }
++         case 3: {
++           goto s_n_llhttp__internal__n_span_end_stub_schema;
++@@ -3274,7 +3314,7 @@
++           goto s_n_llhttp__internal__n_url_schema;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_44;
+++          goto s_n_llhttp__internal__n_error_47;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3310,7 +3350,7 @@
++         }
++         case 2: {
++           p++;
++-          goto s_n_llhttp__internal__n_error_42;
+++          goto s_n_llhttp__internal__n_error_45;
++         }
++         case 3: {
++           goto s_n_llhttp__internal__n_span_start_stub_path_2;
++@@ -3319,7 +3359,7 @@
++           goto s_n_llhttp__internal__n_url_schema;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_45;
+++          goto s_n_llhttp__internal__n_error_48;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3417,7 +3457,7 @@
++           goto s_n_llhttp__internal__n_req_spaces_before_url;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_46;
+++          goto s_n_llhttp__internal__n_error_49;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3442,7 +3482,7 @@
++           return s_n_llhttp__internal__n_start_req_1;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3467,7 +3507,7 @@
++           return s_n_llhttp__internal__n_start_req_2;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3492,7 +3532,7 @@
++           return s_n_llhttp__internal__n_start_req_4;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3517,7 +3557,7 @@
++           return s_n_llhttp__internal__n_start_req_6;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3535,7 +3575,7 @@
++           goto s_n_llhttp__internal__n_invoke_store_method_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3556,7 +3596,7 @@
++           goto s_n_llhttp__internal__n_start_req_7;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3577,7 +3617,7 @@
++           goto s_n_llhttp__internal__n_start_req_5;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3602,7 +3642,7 @@
++           return s_n_llhttp__internal__n_start_req_8;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3627,7 +3667,7 @@
++           return s_n_llhttp__internal__n_start_req_9;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3652,7 +3692,7 @@
++           return s_n_llhttp__internal__n_start_req_10;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3677,7 +3717,7 @@
++           return s_n_llhttp__internal__n_start_req_12;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3702,7 +3742,7 @@
++           return s_n_llhttp__internal__n_start_req_13;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3723,7 +3763,7 @@
++           goto s_n_llhttp__internal__n_start_req_13;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3748,7 +3788,7 @@
++           return s_n_llhttp__internal__n_start_req_15;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3773,7 +3813,7 @@
++           return s_n_llhttp__internal__n_start_req_16;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3798,7 +3838,7 @@
++           return s_n_llhttp__internal__n_start_req_18;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3823,7 +3863,7 @@
++           return s_n_llhttp__internal__n_start_req_20;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3841,7 +3881,7 @@
++           goto s_n_llhttp__internal__n_invoke_store_method_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3862,7 +3902,7 @@
++           goto s_n_llhttp__internal__n_start_req_21;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3883,7 +3923,7 @@
++           goto s_n_llhttp__internal__n_start_req_19;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3908,7 +3948,7 @@
++           return s_n_llhttp__internal__n_start_req_22;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3937,7 +3977,7 @@
++           goto s_n_llhttp__internal__n_start_req_22;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3962,7 +4002,7 @@
++           return s_n_llhttp__internal__n_start_req_23;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -3987,7 +4027,7 @@
++           return s_n_llhttp__internal__n_start_req_24;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4012,7 +4052,7 @@
++           return s_n_llhttp__internal__n_start_req_26;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4037,7 +4077,7 @@
++           return s_n_llhttp__internal__n_start_req_27;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4062,7 +4102,7 @@
++           return s_n_llhttp__internal__n_start_req_31;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4087,7 +4127,7 @@
++           return s_n_llhttp__internal__n_start_req_32;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4108,7 +4148,7 @@
++           goto s_n_llhttp__internal__n_start_req_32;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4125,7 +4165,7 @@
++           goto s_n_llhttp__internal__n_start_req_30;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4147,7 +4187,7 @@
++           goto s_n_llhttp__internal__n_start_req_29;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4172,7 +4212,7 @@
++           return s_n_llhttp__internal__n_start_req_34;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4194,7 +4234,7 @@
++           goto s_n_llhttp__internal__n_invoke_store_method_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4223,7 +4263,7 @@
++           goto s_n_llhttp__internal__n_start_req_33;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4248,7 +4288,7 @@
++           return s_n_llhttp__internal__n_start_req_37;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4273,7 +4313,7 @@
++           return s_n_llhttp__internal__n_start_req_38;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4294,7 +4334,7 @@
++           goto s_n_llhttp__internal__n_start_req_38;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4311,7 +4351,7 @@
++           goto s_n_llhttp__internal__n_start_req_36;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4336,7 +4376,7 @@
++           return s_n_llhttp__internal__n_start_req_40;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4361,7 +4401,7 @@
++           return s_n_llhttp__internal__n_start_req_41;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4386,7 +4426,7 @@
++           return s_n_llhttp__internal__n_start_req_42;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4411,7 +4451,7 @@
++           goto s_n_llhttp__internal__n_start_req_42;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4436,7 +4476,7 @@
++           return s_n_llhttp__internal__n_start_req_43;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4461,7 +4501,7 @@
++           return s_n_llhttp__internal__n_start_req_46;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4486,7 +4526,7 @@
++           return s_n_llhttp__internal__n_start_req_48;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4511,7 +4551,7 @@
++           return s_n_llhttp__internal__n_start_req_49;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4532,7 +4572,7 @@
++           goto s_n_llhttp__internal__n_start_req_49;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4557,7 +4597,7 @@
++           return s_n_llhttp__internal__n_start_req_50;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4582,7 +4622,7 @@
++           goto s_n_llhttp__internal__n_start_req_50;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4599,7 +4639,7 @@
++           goto s_n_llhttp__internal__n_start_req_45;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4672,7 +4712,7 @@
++           goto s_n_llhttp__internal__n_start_req_44;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_55;
+++          goto s_n_llhttp__internal__n_error_58;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4689,7 +4729,7 @@
++           goto s_n_llhttp__internal__n_header_field_start;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4764,7 +4804,7 @@
++           goto s_n_llhttp__internal__n_res_status_start;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_49;
+++          goto s_n_llhttp__internal__n_error_52;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4844,7 +4884,7 @@
++           goto s_n_llhttp__internal__n_invoke_update_status_code;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_50;
+++          goto s_n_llhttp__internal__n_error_53;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4907,7 +4947,7 @@
++           goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_51;
+++          goto s_n_llhttp__internal__n_error_54;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4924,7 +4964,7 @@
++           goto s_n_llhttp__internal__n_res_http_minor;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_52;
+++          goto s_n_llhttp__internal__n_error_55;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -4987,7 +5027,7 @@
++           goto s_n_llhttp__internal__n_invoke_store_http_major_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_53;
+++          goto s_n_llhttp__internal__n_error_56;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -5011,7 +5051,7 @@
++           return s_n_llhttp__internal__n_start_res;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_56;
+++          goto s_n_llhttp__internal__n_error_59;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -5036,7 +5076,7 @@
++           return s_n_llhttp__internal__n_req_or_res_method_2;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_54;
+++          goto s_n_llhttp__internal__n_error_57;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -5060,7 +5100,7 @@
++           return s_n_llhttp__internal__n_req_or_res_method_3;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_54;
+++          goto s_n_llhttp__internal__n_error_57;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -5081,7 +5121,7 @@
++           goto s_n_llhttp__internal__n_req_or_res_method_3;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_54;
+++          goto s_n_llhttp__internal__n_error_57;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -5098,7 +5138,7 @@
++           goto s_n_llhttp__internal__n_req_or_res_method_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_54;
+++          goto s_n_llhttp__internal__n_error_57;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -5167,7 +5207,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_42: {
+++  s_n_llhttp__internal__n_error_45: {
++     state->error = 0x7;
++     state->reason = "Invalid characters in url";
++     state->error_pos = (const char*) p;
++@@ -5655,7 +5695,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_21: {
+++  s_n_llhttp__internal__n_error_22: {
++     state->error = 0xb;
++     state->reason = "Empty Content-Length";
++     state->error_pos = (const char*) p;
++@@ -5740,14 +5780,33 @@
++   s_n_llhttp__internal__n_invoke_load_header_state: {
++     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
++       case 2:
++-        goto s_n_llhttp__internal__n_error_21;
+++        goto s_n_llhttp__internal__n_error_22;
++       default:
++         goto s_n_llhttp__internal__n_invoke_load_header_state_1;
++     }
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_22: {
+++  s_n_llhttp__internal__n_error_21: {
+++    state->error = 0xa;
+++    state->reason = "Invalid header value char";
+++    state->error_pos = (const char*) p;
+++    state->_current = (void*) (intptr_t) s_error;
+++    return s_error;
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_test_flags_5: {
+++    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+++      case 1:
+++        goto s_n_llhttp__internal__n_header_value_discard_lws;
+++      default:
+++        goto s_n_llhttp__internal__n_error_21;
+++    }
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_error_23: {
++     state->error = 0x2;
++     state->reason = "Expected LF after CR";
++     state->error_pos = (const char*) p;
++@@ -5757,6 +5816,24 @@
++     abort();
++   }
++   s_n_llhttp__internal__n_invoke_update_header_state_1: {
+++    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
+++      default:
+++        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+++    }
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_load_header_state_3: {
+++    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
+++      case 8:
+++        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+++      default:
+++        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+++    }
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_update_header_state_2: {
++     switch (llhttp__internal__c_update_header_state(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_field_start;
++@@ -5767,7 +5844,7 @@
++   s_n_llhttp__internal__n_invoke_or_flags_7: {
++     switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
++       default:
++-        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+++        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
++     }
++     /* UNREACHABLE */;
++     abort();
++@@ -5775,7 +5852,7 @@
++   s_n_llhttp__internal__n_invoke_or_flags_8: {
++     switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
++       default:
++-        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+++        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
++     }
++     /* UNREACHABLE */;
++     abort();
++@@ -5783,7 +5860,7 @@
++   s_n_llhttp__internal__n_invoke_or_flags_9: {
++     switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
++       default:
++-        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+++        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
++     }
++     /* UNREACHABLE */;
++     abort();
++@@ -5796,7 +5873,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_load_header_state_3: {
+++  s_n_llhttp__internal__n_invoke_load_header_state_4: {
++     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
++       case 5:
++         goto s_n_llhttp__internal__n_invoke_or_flags_7;
++@@ -5812,7 +5889,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_23: {
+++  s_n_llhttp__internal__n_error_24: {
++     state->error = 0x3;
++     state->reason = "Missing expected LF after header value";
++     state->error_pos = (const char*) p;
++@@ -5830,6 +5907,24 @@
++     err = llhttp__on_header_value(state, start, p);
++     if (err != 0) {
++       state->error = err;
+++      state->error_pos = (const char*) (p + 1);
+++      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
+++      return s_error;
+++    }
+++    p++;
+++    goto s_n_llhttp__internal__n_header_value_almost_done;
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3: {
+++    const unsigned char* start;
+++    int err;
+++    
+++    start = state->_span_pos0;
+++    state->_span_pos0 = NULL;
+++    err = llhttp__on_header_value(state, start, p);
+++    if (err != 0) {
+++      state->error = err;
++       state->error_pos = (const char*) p;
++       state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
++       return s_error;
++@@ -5838,7 +5933,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2: {
+++  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4: {
++     const unsigned char* start;
++     int err;
++     
++@@ -5856,7 +5951,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3: {
+++  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2: {
++     const unsigned char* start;
++     int err;
++     
++@@ -5865,35 +5960,25 @@
++     err = llhttp__on_header_value(state, start, p);
++     if (err != 0) {
++       state->error = err;
++-      state->error_pos = (const char*) (p + 1);
++-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
+++      state->error_pos = (const char*) p;
+++      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_25;
++       return s_error;
++     }
++-    p++;
++-    goto s_n_llhttp__internal__n_header_value_almost_done;
++-    /* UNREACHABLE */;
++-    abort();
++-  }
++-  s_n_llhttp__internal__n_error_24: {
++-    state->error = 0xa;
++-    state->reason = "Invalid header value char";
++-    state->error_pos = (const char*) p;
++-    state->_current = (void*) (intptr_t) s_error;
++-    return s_error;
+++    goto s_n_llhttp__internal__n_error_25;
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_test_flags_5: {
+++  s_n_llhttp__internal__n_invoke_test_flags_6: {
++     switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
++       case 1:
++         goto s_n_llhttp__internal__n_header_value_lenient;
++       default:
++-        goto s_n_llhttp__internal__n_error_24;
+++        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2;
++     }
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_update_header_state_3: {
+++  s_n_llhttp__internal__n_invoke_update_header_state_4: {
++     switch (llhttp__internal__c_update_header_state(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_value_connection;
++@@ -5904,7 +5989,7 @@
++   s_n_llhttp__internal__n_invoke_or_flags_11: {
++     switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
++       default:
++-        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+++        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
++     }
++     /* UNREACHABLE */;
++     abort();
++@@ -5912,7 +5997,7 @@
++   s_n_llhttp__internal__n_invoke_or_flags_12: {
++     switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
++       default:
++-        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+++        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
++     }
++     /* UNREACHABLE */;
++     abort();
++@@ -5920,7 +6005,7 @@
++   s_n_llhttp__internal__n_invoke_or_flags_13: {
++     switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
++       default:
++-        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+++        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
++     }
++     /* UNREACHABLE */;
++     abort();
++@@ -5933,7 +6018,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_load_header_state_4: {
+++  s_n_llhttp__internal__n_invoke_load_header_state_5: {
++     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
++       case 5:
++         goto s_n_llhttp__internal__n_invoke_or_flags_11;
++@@ -5949,39 +6034,39 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_update_header_state_4: {
++-    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+++  s_n_llhttp__internal__n_invoke_update_header_state_5: {
+++    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_value_connection_token;
++     }
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_update_header_state_2: {
++-    switch (llhttp__internal__c_update_header_state_2(state, p, endp)) {
+++  s_n_llhttp__internal__n_invoke_update_header_state_3: {
+++    switch (llhttp__internal__c_update_header_state_3(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_value_connection_ws;
++     }
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_update_header_state_5: {
++-    switch (llhttp__internal__c_update_header_state_5(state, p, endp)) {
+++  s_n_llhttp__internal__n_invoke_update_header_state_6: {
+++    switch (llhttp__internal__c_update_header_state_6(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_value_connection_ws;
++     }
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_update_header_state_6: {
++-    switch (llhttp__internal__c_update_header_state_6(state, p, endp)) {
+++  s_n_llhttp__internal__n_invoke_update_header_state_7: {
+++    switch (llhttp__internal__c_update_header_state_7(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_value_connection_ws;
++     }
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4: {
+++  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5: {
++     const unsigned char* start;
++     int err;
++     
++@@ -5991,17 +6076,17 @@
++     if (err != 0) {
++       state->error = err;
++       state->error_pos = (const char*) p;
++-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_26;
+++      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_27;
++       return s_error;
++     }
++-    goto s_n_llhttp__internal__n_error_26;
+++    goto s_n_llhttp__internal__n_error_27;
++     /* UNREACHABLE */;
++     abort();
++   }
++   s_n_llhttp__internal__n_invoke_mul_add_content_length_1: {
++     switch (llhttp__internal__c_mul_add_content_length_1(state, p, endp, match)) {
++       case 1:
++-        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4;
+++        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5;
++       default:
++         goto s_n_llhttp__internal__n_header_value_content_length;
++     }
++@@ -6016,7 +6101,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5: {
+++  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_6: {
++     const unsigned char* start;
++     int err;
++     
++@@ -6026,14 +6111,14 @@
++     if (err != 0) {
++       state->error = err;
++       state->error_pos = (const char*) p;
++-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_27;
+++      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_28;
++       return s_error;
++     }
++-    goto s_n_llhttp__internal__n_error_27;
+++    goto s_n_llhttp__internal__n_error_28;
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_25: {
+++  s_n_llhttp__internal__n_error_26: {
++     state->error = 0x4;
++     state->reason = "Duplicate Content-Length";
++     state->error_pos = (const char*) p;
++@@ -6042,26 +6127,82 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_test_flags_6: {
++-    switch (llhttp__internal__c_test_flags_6(state, p, endp)) {
+++  s_n_llhttp__internal__n_invoke_test_flags_7: {
+++    switch (llhttp__internal__c_test_flags_7(state, p, endp)) {
++       case 0:
++         goto s_n_llhttp__internal__n_header_value_content_length;
++       default:
++-        goto s_n_llhttp__internal__n_error_25;
+++        goto s_n_llhttp__internal__n_error_26;
++     }
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_update_header_state_7: {
++-    switch (llhttp__internal__c_update_header_state_7(state, p, endp)) {
+++  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_8: {
+++    const unsigned char* start;
+++    int err;
+++    
+++    start = state->_span_pos0;
+++    state->_span_pos0 = NULL;
+++    err = llhttp__on_header_value(state, start, p);
+++    if (err != 0) {
+++      state->error = err;
+++      state->error_pos = (const char*) (p + 1);
+++      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_30;
+++      return s_error;
+++    }
+++    p++;
+++    goto s_n_llhttp__internal__n_error_30;
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_update_header_state_8: {
+++    switch (llhttp__internal__c_update_header_state_8(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_value_otherwise;
++     }
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_update_header_state_8: {
++-    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+++  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_7: {
+++    const unsigned char* start;
+++    int err;
+++    
+++    start = state->_span_pos0;
+++    state->_span_pos0 = NULL;
+++    err = llhttp__on_header_value(state, start, p);
+++    if (err != 0) {
+++      state->error = err;
+++      state->error_pos = (const char*) (p + 1);
+++      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_29;
+++      return s_error;
+++    }
+++    p++;
+++    goto s_n_llhttp__internal__n_error_29;
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_test_flags_9: {
+++    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+++      case 0:
+++        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_7;
+++      default:
+++        goto s_n_llhttp__internal__n_header_value_te_chunked;
+++    }
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_load_type_1: {
+++    switch (llhttp__internal__c_load_type(state, p, endp)) {
+++      case 1:
+++        goto s_n_llhttp__internal__n_invoke_test_flags_9;
+++      default:
+++        goto s_n_llhttp__internal__n_header_value_te_chunked;
+++    }
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_update_header_state_9: {
+++    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_value;
++     }
++@@ -6076,6 +6217,34 @@
++     /* UNREACHABLE */;
++     abort();
++   }
+++  s_n_llhttp__internal__n_invoke_or_flags_17: {
+++    switch (llhttp__internal__c_or_flags_16(state, p, endp)) {
+++      default:
+++        goto s_n_llhttp__internal__n_invoke_and_flags;
+++    }
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_test_flags_10: {
+++    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+++      case 0:
+++        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_8;
+++      default:
+++        goto s_n_llhttp__internal__n_invoke_or_flags_17;
+++    }
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_load_type_2: {
+++    switch (llhttp__internal__c_load_type(state, p, endp)) {
+++      case 1:
+++        goto s_n_llhttp__internal__n_invoke_test_flags_10;
+++      default:
+++        goto s_n_llhttp__internal__n_invoke_or_flags_17;
+++    }
+++    /* UNREACHABLE */;
+++    abort();
+++  }
++   s_n_llhttp__internal__n_invoke_or_flags_16: {
++     switch (llhttp__internal__c_or_flags_16(state, p, endp)) {
++       default:
++@@ -6084,10 +6253,20 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_or_flags_17: {
++-    switch (llhttp__internal__c_or_flags_17(state, p, endp)) {
+++  s_n_llhttp__internal__n_invoke_test_flags_8: {
+++    switch (llhttp__internal__c_test_flags_8(state, p, endp)) {
+++      case 1:
+++        goto s_n_llhttp__internal__n_invoke_load_type_2;
++       default:
++-        goto s_n_llhttp__internal__n_invoke_update_header_state_8;
+++        goto s_n_llhttp__internal__n_invoke_or_flags_16;
+++    }
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_or_flags_18: {
+++    switch (llhttp__internal__c_or_flags_18(state, p, endp)) {
+++      default:
+++        goto s_n_llhttp__internal__n_invoke_update_header_state_9;
++     }
++     /* UNREACHABLE */;
++     abort();
++@@ -6097,11 +6276,11 @@
++       case 1:
++         goto s_n_llhttp__internal__n_header_value_connection;
++       case 2:
++-        goto s_n_llhttp__internal__n_invoke_test_flags_6;
+++        goto s_n_llhttp__internal__n_invoke_test_flags_7;
++       case 3:
++-        goto s_n_llhttp__internal__n_invoke_or_flags_16;
+++        goto s_n_llhttp__internal__n_invoke_test_flags_8;
++       case 4:
++-        goto s_n_llhttp__internal__n_invoke_or_flags_17;
+++        goto s_n_llhttp__internal__n_invoke_or_flags_18;
++       default:
++         goto s_n_llhttp__internal__n_header_value;
++     }
++@@ -6144,7 +6323,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_28: {
+++  s_n_llhttp__internal__n_error_31: {
++     state->error = 0xa;
++     state->reason = "Invalid header token";
++     state->error_pos = (const char*) p;
++@@ -6153,8 +6332,8 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_update_header_state_9: {
++-    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+++  s_n_llhttp__internal__n_invoke_update_header_state_10: {
+++    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_field_general;
++     }
++@@ -6169,8 +6348,8 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_update_header_state_10: {
++-    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+++  s_n_llhttp__internal__n_invoke_update_header_state_11: {
+++    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_field_general;
++     }
++@@ -6210,7 +6389,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_29: {
+++  s_n_llhttp__internal__n_error_32: {
++     state->error = 0x7;
++     state->reason = "Expected CRLF";
++     state->error_pos = (const char*) p;
++@@ -6236,7 +6415,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_30: {
+++  s_n_llhttp__internal__n_error_33: {
++     state->error = 0x9;
++     state->reason = "Expected CRLF after version";
++     state->error_pos = (const char*) p;
++@@ -6253,7 +6432,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_31: {
+++  s_n_llhttp__internal__n_error_34: {
++     state->error = 0x9;
++     state->reason = "Invalid minor version";
++     state->error_pos = (const char*) p;
++@@ -6262,7 +6441,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_32: {
+++  s_n_llhttp__internal__n_error_35: {
++     state->error = 0x9;
++     state->reason = "Expected dot";
++     state->error_pos = (const char*) p;
++@@ -6279,7 +6458,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_33: {
+++  s_n_llhttp__internal__n_error_36: {
++     state->error = 0x9;
++     state->reason = "Invalid major version";
++     state->error_pos = (const char*) p;
++@@ -6288,7 +6467,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_35: {
+++  s_n_llhttp__internal__n_error_38: {
++     state->error = 0x8;
++     state->reason = "Expected HTTP/";
++     state->error_pos = (const char*) p;
++@@ -6297,7 +6476,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_34: {
+++  s_n_llhttp__internal__n_error_37: {
++     state->error = 0x8;
++     state->reason = "Expected SOURCE method for ICE/x.x request";
++     state->error_pos = (const char*) p;
++@@ -6309,7 +6488,7 @@
++   s_n_llhttp__internal__n_invoke_is_equal_method_1: {
++     switch (llhttp__internal__c_is_equal_method_1(state, p, endp)) {
++       case 0:
++-        goto s_n_llhttp__internal__n_error_34;
+++        goto s_n_llhttp__internal__n_error_37;
++       default:
++         goto s_n_llhttp__internal__n_req_http_major;
++     }
++@@ -6384,7 +6563,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_36: {
+++  s_n_llhttp__internal__n_error_39: {
++     state->error = 0x7;
++     state->reason = "Invalid char in url fragment start";
++     state->error_pos = (const char*) p;
++@@ -6444,7 +6623,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_37: {
+++  s_n_llhttp__internal__n_error_40: {
++     state->error = 0x7;
++     state->reason = "Invalid char in url query";
++     state->error_pos = (const char*) p;
++@@ -6453,7 +6632,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_38: {
+++  s_n_llhttp__internal__n_error_41: {
++     state->error = 0x7;
++     state->reason = "Invalid char in url path";
++     state->error_pos = (const char*) p;
++@@ -6564,7 +6743,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_39: {
+++  s_n_llhttp__internal__n_error_42: {
++     state->error = 0x7;
++     state->reason = "Double @ in url";
++     state->error_pos = (const char*) p;
++@@ -6573,7 +6752,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_40: {
+++  s_n_llhttp__internal__n_error_43: {
++     state->error = 0x7;
++     state->reason = "Unexpected char in url server";
++     state->error_pos = (const char*) p;
++@@ -6582,7 +6761,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_41: {
+++  s_n_llhttp__internal__n_error_44: {
++     state->error = 0x7;
++     state->reason = "Unexpected char in url server";
++     state->error_pos = (const char*) p;
++@@ -6591,7 +6770,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_43: {
+++  s_n_llhttp__internal__n_error_46: {
++     state->error = 0x7;
++     state->reason = "Unexpected char in url schema";
++     state->error_pos = (const char*) p;
++@@ -6600,7 +6779,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_44: {
+++  s_n_llhttp__internal__n_error_47: {
++     state->error = 0x7;
++     state->reason = "Unexpected char in url schema";
++     state->error_pos = (const char*) p;
++@@ -6609,7 +6788,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_45: {
+++  s_n_llhttp__internal__n_error_48: {
++     state->error = 0x7;
++     state->reason = "Unexpected start char in url";
++     state->error_pos = (const char*) p;
++@@ -6628,7 +6807,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_46: {
+++  s_n_llhttp__internal__n_error_49: {
++     state->error = 0x6;
++     state->reason = "Expected space after method";
++     state->error_pos = (const char*) p;
++@@ -6645,7 +6824,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_55: {
+++  s_n_llhttp__internal__n_error_58: {
++     state->error = 0x6;
++     state->reason = "Invalid method encountered";
++     state->error_pos = (const char*) p;
++@@ -6654,7 +6833,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_47: {
+++  s_n_llhttp__internal__n_error_50: {
++     state->error = 0xd;
++     state->reason = "Response overflow";
++     state->error_pos = (const char*) p;
++@@ -6666,14 +6845,14 @@
++   s_n_llhttp__internal__n_invoke_mul_add_status_code: {
++     switch (llhttp__internal__c_mul_add_status_code(state, p, endp, match)) {
++       case 1:
++-        goto s_n_llhttp__internal__n_error_47;
+++        goto s_n_llhttp__internal__n_error_50;
++       default:
++         goto s_n_llhttp__internal__n_res_status_code;
++     }
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_48: {
+++  s_n_llhttp__internal__n_error_51: {
++     state->error = 0x2;
++     state->reason = "Expected LF after CR";
++     state->error_pos = (const char*) p;
++@@ -6718,7 +6897,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_49: {
+++  s_n_llhttp__internal__n_error_52: {
++     state->error = 0xd;
++     state->reason = "Invalid response status";
++     state->error_pos = (const char*) p;
++@@ -6735,7 +6914,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_50: {
+++  s_n_llhttp__internal__n_error_53: {
++     state->error = 0x9;
++     state->reason = "Expected space after version";
++     state->error_pos = (const char*) p;
++@@ -6752,7 +6931,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_51: {
+++  s_n_llhttp__internal__n_error_54: {
++     state->error = 0x9;
++     state->reason = "Invalid minor version";
++     state->error_pos = (const char*) p;
++@@ -6761,7 +6940,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_52: {
+++  s_n_llhttp__internal__n_error_55: {
++     state->error = 0x9;
++     state->reason = "Expected dot";
++     state->error_pos = (const char*) p;
++@@ -6778,7 +6957,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_53: {
+++  s_n_llhttp__internal__n_error_56: {
++     state->error = 0x9;
++     state->reason = "Invalid major version";
++     state->error_pos = (const char*) p;
++@@ -6787,7 +6966,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_56: {
+++  s_n_llhttp__internal__n_error_59: {
++     state->error = 0x8;
++     state->reason = "Expected HTTP/";
++     state->error_pos = (const char*) p;
++@@ -6812,7 +6991,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_54: {
+++  s_n_llhttp__internal__n_error_57: {
++     state->error = 0x8;
++     state->reason = "Invalid word encountered";
++     state->error_pos = (const char*) p;
++@@ -7244,6 +7423,7 @@
++   s_n_llhttp__internal__n_header_value_lws,
++   s_n_llhttp__internal__n_header_value_almost_done,
++   s_n_llhttp__internal__n_header_value_lenient,
+++  s_n_llhttp__internal__n_error_19,
++   s_n_llhttp__internal__n_header_value_otherwise,
++   s_n_llhttp__internal__n_header_value_connection_token,
++   s_n_llhttp__internal__n_header_value_connection_ws,
++@@ -7251,14 +7431,16 @@
++   s_n_llhttp__internal__n_header_value_connection_2,
++   s_n_llhttp__internal__n_header_value_connection_3,
++   s_n_llhttp__internal__n_header_value_connection,
++-  s_n_llhttp__internal__n_error_20,
++   s_n_llhttp__internal__n_error_21,
+++  s_n_llhttp__internal__n_error_22,
++   s_n_llhttp__internal__n_header_value_content_length_ws,
++   s_n_llhttp__internal__n_header_value_content_length,
++-  s_n_llhttp__internal__n_header_value_te_chunked_last,
+++  s_n_llhttp__internal__n_error_24,
+++  s_n_llhttp__internal__n_error_23,
++   s_n_llhttp__internal__n_header_value_te_token_ows,
++   s_n_llhttp__internal__n_header_value,
++   s_n_llhttp__internal__n_header_value_te_token,
+++  s_n_llhttp__internal__n_header_value_te_chunked_last,
++   s_n_llhttp__internal__n_header_value_te_chunked,
++   s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1,
++   s_n_llhttp__internal__n_header_value_discard_ws,
++@@ -7648,7 +7830,7 @@
++   return 0;
++ }
++ 
++-int llhttp__internal__c_update_header_state_2(
+++int llhttp__internal__c_update_header_state_3(
++     llhttp__internal_t* state,
++     const unsigned char* p,
++     const unsigned char* endp) {
++@@ -7656,7 +7838,7 @@
++   return 0;
++ }
++ 
++-int llhttp__internal__c_update_header_state_4(
+++int llhttp__internal__c_update_header_state_1(
++     llhttp__internal_t* state,
++     const unsigned char* p,
++     const unsigned char* endp) {
++@@ -7664,7 +7846,7 @@
++   return 0;
++ }
++ 
++-int llhttp__internal__c_update_header_state_5(
+++int llhttp__internal__c_update_header_state_6(
++     llhttp__internal_t* state,
++     const unsigned char* p,
++     const unsigned char* endp) {
++@@ -7672,7 +7854,7 @@
++   return 0;
++ }
++ 
++-int llhttp__internal__c_update_header_state_6(
+++int llhttp__internal__c_update_header_state_7(
++     llhttp__internal_t* state,
++     const unsigned char* p,
++     const unsigned char* endp) {
++@@ -7680,7 +7862,7 @@
++   return 0;
++ }
++ 
++-int llhttp__internal__c_test_flags_6(
+++int llhttp__internal__c_test_flags_7(
++     llhttp__internal_t* state,
++     const unsigned char* p,
++     const unsigned char* endp) {
++@@ -7721,6 +7903,13 @@
++   return 0;
++ }
++ 
+++int llhttp__internal__c_test_flags_8(
+++    llhttp__internal_t* state,
+++    const unsigned char* p,
+++    const unsigned char* endp) {
+++  return (state->flags & 8) == 8;
+++}
+++
++ int llhttp__internal__c_or_flags_16(
++     llhttp__internal_t* state,
++     const unsigned char* p,
++@@ -7737,7 +7926,7 @@
++   return 0;
++ }
++ 
++-int llhttp__internal__c_update_header_state_7(
+++int llhttp__internal__c_update_header_state_8(
++     llhttp__internal_t* state,
++     const unsigned char* p,
++     const unsigned char* endp) {
++@@ -7745,7 +7934,7 @@
++   return 0;
++ }
++ 
++-int llhttp__internal__c_or_flags_17(
+++int llhttp__internal__c_or_flags_18(
++     llhttp__internal_t* state,
++     const unsigned char* p,
++     const unsigned char* endp) {
++@@ -8432,13 +8621,13 @@
++       }
++       switch (*p) {
++         case 9: {
++-          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+++          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
++         }
++         case ' ': {
++-          goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+++          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_invoke_load_header_state_3;
+++          goto s_n_llhttp__internal__n_invoke_load_header_state_4;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -8455,7 +8644,7 @@
++           goto s_n_llhttp__internal__n_header_value_lws;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_17;
+++          goto s_n_llhttp__internal__n_error_18;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -8468,10 +8657,10 @@
++       }
++       switch (*p) {
++         case 10: {
++-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
+++          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3;
++         }
++         case 13: {
++-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3;
+++          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4;
++         }
++         default: {
++           p++;
++@@ -8481,20 +8670,27 @@
++       /* UNREACHABLE */;
++       abort();
++     }
+++    case s_n_llhttp__internal__n_error_19:
+++    s_n_llhttp__internal__n_error_19: {
+++      state->error = 0xa;
+++      state->reason = "Invalid header value char";
+++      state->error_pos = (const char*) p;
+++      state->_current = (void*) (intptr_t) s_error;
+++      return s_error;
+++      /* UNREACHABLE */;
+++      abort();
+++    }
++     case s_n_llhttp__internal__n_header_value_otherwise:
++     s_n_llhttp__internal__n_header_value_otherwise: {
++       if (p == endp) {
++         return s_n_llhttp__internal__n_header_value_otherwise;
++       }
++       switch (*p) {
++-        case 10: {
++-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
++-        }
++         case 13: {
++-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2;
+++          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_invoke_test_flags_5;
+++          goto s_n_llhttp__internal__n_invoke_test_flags_6;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -8557,10 +8753,10 @@
++         }
++         case ',': {
++           p++;
++-          goto s_n_llhttp__internal__n_invoke_load_header_state_4;
+++          goto s_n_llhttp__internal__n_invoke_load_header_state_5;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_4;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_5;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -8578,7 +8774,7 @@
++       switch (match_seq.status) {
++         case kMatchComplete: {
++           p++;
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_2;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_3;
++         }
++         case kMatchPause: {
++           return s_n_llhttp__internal__n_header_value_connection_1;
++@@ -8602,7 +8798,7 @@
++       switch (match_seq.status) {
++         case kMatchComplete: {
++           p++;
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_5;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_6;
++         }
++         case kMatchPause: {
++           return s_n_llhttp__internal__n_header_value_connection_2;
++@@ -8626,7 +8822,7 @@
++       switch (match_seq.status) {
++         case kMatchComplete: {
++           p++;
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_6;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
++         }
++         case kMatchPause: {
++           return s_n_llhttp__internal__n_header_value_connection_3;
++@@ -8671,8 +8867,8 @@
++       /* UNREACHABLE */;
++       abort();
++     }
++-    case s_n_llhttp__internal__n_error_20:
++-    s_n_llhttp__internal__n_error_20: {
+++    case s_n_llhttp__internal__n_error_21:
+++    s_n_llhttp__internal__n_error_21: {
++       state->error = 0xb;
++       state->reason = "Content-Length overflow";
++       state->error_pos = (const char*) p;
++@@ -8681,8 +8877,8 @@
++       /* UNREACHABLE */;
++       abort();
++     }
++-    case s_n_llhttp__internal__n_error_21:
++-    s_n_llhttp__internal__n_error_21: {
+++    case s_n_llhttp__internal__n_error_22:
+++    s_n_llhttp__internal__n_error_22: {
++       state->error = 0xb;
++       state->reason = "Invalid character in Content-Length";
++       state->error_pos = (const char*) p;
++@@ -8708,7 +8904,7 @@
++           goto s_n_llhttp__internal__n_header_value_content_length_ws;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5;
+++          goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_6;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -8777,26 +8973,23 @@
++       /* UNREACHABLE */;
++       abort();
++     }
++-    case s_n_llhttp__internal__n_header_value_te_chunked_last:
++-    s_n_llhttp__internal__n_header_value_te_chunked_last: {
++-      if (p == endp) {
++-        return s_n_llhttp__internal__n_header_value_te_chunked_last;
++-      }
++-      switch (*p) {
++-        case 10: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
++-        }
++-        case 13: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_7;
++-        }
++-        case ' ': {
++-          p++;
++-          goto s_n_llhttp__internal__n_header_value_te_chunked_last;
++-        }
++-        default: {
++-          goto s_n_llhttp__internal__n_header_value_te_chunked;
++-        }
++-      }
+++    case s_n_llhttp__internal__n_error_24:
+++    s_n_llhttp__internal__n_error_24: {
+++      state->error = 0xf;
+++      state->reason = "Invalid `Transfer-Encoding` header value";
+++      state->error_pos = (const char*) p;
+++      state->_current = (void*) (intptr_t) s_error;
+++      return s_error;
+++      /* UNREACHABLE */;
+++      abort();
+++    }
+++    case s_n_llhttp__internal__n_error_23:
+++    s_n_llhttp__internal__n_error_23: {
+++      state->error = 0xf;
+++      state->reason = "Invalid `Transfer-Encoding` header value";
+++      state->error_pos = (const char*) p;
+++      state->_current = (void*) (intptr_t) s_error;
+++      return s_error;
++       /* UNREACHABLE */;
++       abort();
++     }
++@@ -8913,8 +9106,34 @@
++           goto s_n_llhttp__internal__n_header_value_te_token_ows;
++         }
++         default: {
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_9;
+++        }
+++      }
+++      /* UNREACHABLE */;
+++      abort();
+++    }
+++    case s_n_llhttp__internal__n_header_value_te_chunked_last:
+++    s_n_llhttp__internal__n_header_value_te_chunked_last: {
+++      if (p == endp) {
+++        return s_n_llhttp__internal__n_header_value_te_chunked_last;
+++      }
+++      switch (*p) {
+++        case 10: {
++           goto s_n_llhttp__internal__n_invoke_update_header_state_8;
++         }
+++        case 13: {
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_8;
+++        }
+++        case ' ': {
+++          p++;
+++          goto s_n_llhttp__internal__n_header_value_te_chunked_last;
+++        }
+++        case ',': {
+++          goto s_n_llhttp__internal__n_invoke_load_type_1;
+++        }
+++        default: {
+++          goto s_n_llhttp__internal__n_header_value_te_token;
+++        }
++       }
++       /* UNREACHABLE */;
++       abort();
++@@ -8966,7 +9185,7 @@
++         }
++         case 10: {
++           p++;
++-          goto s_n_llhttp__internal__n_header_value_discard_lws;
+++          goto s_n_llhttp__internal__n_invoke_test_flags_5;
++         }
++         case 13: {
++           p++;
++@@ -8993,7 +9212,7 @@
++           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_2;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_22;
+++          goto s_n_llhttp__internal__n_error_25;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9083,7 +9302,7 @@
++           goto s_n_llhttp__internal__n_span_end_llhttp__on_header_field_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_9;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9108,7 +9327,7 @@
++           return s_n_llhttp__internal__n_header_field_3;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9133,7 +9352,7 @@
++           return s_n_llhttp__internal__n_header_field_4;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9154,7 +9373,7 @@
++           goto s_n_llhttp__internal__n_header_field_4;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9178,7 +9397,7 @@
++           return s_n_llhttp__internal__n_header_field_1;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9203,7 +9422,7 @@
++           return s_n_llhttp__internal__n_header_field_5;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9228,7 +9447,7 @@
++           return s_n_llhttp__internal__n_header_field_6;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9253,7 +9472,7 @@
++           return s_n_llhttp__internal__n_header_field_7;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9282,7 +9501,7 @@
++           goto s_n_llhttp__internal__n_header_field_7;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_invoke_update_header_state_10;
+++          goto s_n_llhttp__internal__n_invoke_update_header_state_11;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9347,7 +9566,7 @@
++           return s_n_llhttp__internal__n_url_skip_lf_to_http09;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_23;
+++          goto s_n_llhttp__internal__n_error_26;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9364,7 +9583,7 @@
++           goto s_n_llhttp__internal__n_header_field_start;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_24;
+++          goto s_n_llhttp__internal__n_error_27;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9385,7 +9604,7 @@
++           goto s_n_llhttp__internal__n_req_http_end_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_24;
+++          goto s_n_llhttp__internal__n_error_27;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9448,7 +9667,7 @@
++           goto s_n_llhttp__internal__n_invoke_store_http_minor;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_25;
+++          goto s_n_llhttp__internal__n_error_28;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9465,7 +9684,7 @@
++           goto s_n_llhttp__internal__n_req_http_minor;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_26;
+++          goto s_n_llhttp__internal__n_error_29;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9528,7 +9747,7 @@
++           goto s_n_llhttp__internal__n_invoke_store_http_major;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_27;
+++          goto s_n_llhttp__internal__n_error_30;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9552,7 +9771,7 @@
++           return s_n_llhttp__internal__n_req_http_start_1;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_29;
+++          goto s_n_llhttp__internal__n_error_32;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9576,7 +9795,7 @@
++           return s_n_llhttp__internal__n_req_http_start_2;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_29;
+++          goto s_n_llhttp__internal__n_error_32;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9601,7 +9820,7 @@
++           goto s_n_llhttp__internal__n_req_http_start_2;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_29;
+++          goto s_n_llhttp__internal__n_error_32;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9655,7 +9874,7 @@
++           goto s_n_llhttp__internal__n_span_end_llhttp__on_url_8;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_30;
+++          goto s_n_llhttp__internal__n_error_33;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9712,7 +9931,7 @@
++           goto s_n_llhttp__internal__n_span_end_stub_query_3;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_31;
+++          goto s_n_llhttp__internal__n_error_34;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9742,7 +9961,7 @@
++           goto s_n_llhttp__internal__n_url_query;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_32;
+++          goto s_n_llhttp__internal__n_error_35;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9883,10 +10102,10 @@
++         }
++         case 7: {
++           p++;
++-          goto s_n_llhttp__internal__n_error_33;
+++          goto s_n_llhttp__internal__n_error_36;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_34;
+++          goto s_n_llhttp__internal__n_error_37;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9941,7 +10160,7 @@
++           goto s_n_llhttp__internal__n_url_server_with_at;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_35;
+++          goto s_n_llhttp__internal__n_error_38;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9958,7 +10177,7 @@
++           goto s_n_llhttp__internal__n_url_server;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_37;
+++          goto s_n_llhttp__internal__n_error_40;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -9972,22 +10191,22 @@
++       switch (*p) {
++         case 10: {
++           p++;
++-          goto s_n_llhttp__internal__n_error_36;
+++          goto s_n_llhttp__internal__n_error_39;
++         }
++         case 13: {
++           p++;
++-          goto s_n_llhttp__internal__n_error_36;
+++          goto s_n_llhttp__internal__n_error_39;
++         }
++         case ' ': {
++           p++;
++-          goto s_n_llhttp__internal__n_error_36;
+++          goto s_n_llhttp__internal__n_error_39;
++         }
++         case '/': {
++           p++;
++           goto s_n_llhttp__internal__n_url_schema_delim_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_37;
+++          goto s_n_llhttp__internal__n_error_40;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10029,7 +10248,7 @@
++       switch (lookup_table[(uint8_t) *p]) {
++         case 1: {
++           p++;
++-          goto s_n_llhttp__internal__n_error_36;
+++          goto s_n_llhttp__internal__n_error_39;
++         }
++         case 2: {
++           goto s_n_llhttp__internal__n_span_end_stub_schema;
++@@ -10039,7 +10258,7 @@
++           goto s_n_llhttp__internal__n_url_schema;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_38;
+++          goto s_n_llhttp__internal__n_error_41;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10071,7 +10290,7 @@
++       switch (lookup_table[(uint8_t) *p]) {
++         case 1: {
++           p++;
++-          goto s_n_llhttp__internal__n_error_36;
+++          goto s_n_llhttp__internal__n_error_39;
++         }
++         case 2: {
++           goto s_n_llhttp__internal__n_span_start_stub_path_2;
++@@ -10080,7 +10299,7 @@
++           goto s_n_llhttp__internal__n_url_schema;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_39;
+++          goto s_n_llhttp__internal__n_error_42;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10136,7 +10355,7 @@
++           goto s_n_llhttp__internal__n_req_spaces_before_url;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_40;
+++          goto s_n_llhttp__internal__n_error_43;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10161,7 +10380,7 @@
++           return s_n_llhttp__internal__n_start_req_1;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10186,7 +10405,7 @@
++           return s_n_llhttp__internal__n_start_req_2;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10211,7 +10430,7 @@
++           return s_n_llhttp__internal__n_start_req_4;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10236,7 +10455,7 @@
++           return s_n_llhttp__internal__n_start_req_6;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10254,7 +10473,7 @@
++           goto s_n_llhttp__internal__n_invoke_store_method_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10275,7 +10494,7 @@
++           goto s_n_llhttp__internal__n_start_req_7;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10296,7 +10515,7 @@
++           goto s_n_llhttp__internal__n_start_req_5;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10321,7 +10540,7 @@
++           return s_n_llhttp__internal__n_start_req_8;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10346,7 +10565,7 @@
++           return s_n_llhttp__internal__n_start_req_9;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10371,7 +10590,7 @@
++           return s_n_llhttp__internal__n_start_req_10;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10396,7 +10615,7 @@
++           return s_n_llhttp__internal__n_start_req_12;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10421,7 +10640,7 @@
++           return s_n_llhttp__internal__n_start_req_13;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10442,7 +10661,7 @@
++           goto s_n_llhttp__internal__n_start_req_13;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10467,7 +10686,7 @@
++           return s_n_llhttp__internal__n_start_req_15;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10492,7 +10711,7 @@
++           return s_n_llhttp__internal__n_start_req_16;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10517,7 +10736,7 @@
++           return s_n_llhttp__internal__n_start_req_18;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10542,7 +10761,7 @@
++           return s_n_llhttp__internal__n_start_req_20;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10560,7 +10779,7 @@
++           goto s_n_llhttp__internal__n_invoke_store_method_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10581,7 +10800,7 @@
++           goto s_n_llhttp__internal__n_start_req_21;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10602,7 +10821,7 @@
++           goto s_n_llhttp__internal__n_start_req_19;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10627,7 +10846,7 @@
++           return s_n_llhttp__internal__n_start_req_22;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10656,7 +10875,7 @@
++           goto s_n_llhttp__internal__n_start_req_22;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10681,7 +10900,7 @@
++           return s_n_llhttp__internal__n_start_req_23;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10706,7 +10925,7 @@
++           return s_n_llhttp__internal__n_start_req_24;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10731,7 +10950,7 @@
++           return s_n_llhttp__internal__n_start_req_26;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10756,7 +10975,7 @@
++           return s_n_llhttp__internal__n_start_req_27;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10781,7 +11000,7 @@
++           return s_n_llhttp__internal__n_start_req_31;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10806,7 +11025,7 @@
++           return s_n_llhttp__internal__n_start_req_32;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10827,7 +11046,7 @@
++           goto s_n_llhttp__internal__n_start_req_32;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10844,7 +11063,7 @@
++           goto s_n_llhttp__internal__n_start_req_30;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10866,7 +11085,7 @@
++           goto s_n_llhttp__internal__n_start_req_29;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10891,7 +11110,7 @@
++           return s_n_llhttp__internal__n_start_req_34;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10913,7 +11132,7 @@
++           goto s_n_llhttp__internal__n_invoke_store_method_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10942,7 +11161,7 @@
++           goto s_n_llhttp__internal__n_start_req_33;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10967,7 +11186,7 @@
++           return s_n_llhttp__internal__n_start_req_37;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -10992,7 +11211,7 @@
++           return s_n_llhttp__internal__n_start_req_38;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11013,7 +11232,7 @@
++           goto s_n_llhttp__internal__n_start_req_38;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11030,7 +11249,7 @@
++           goto s_n_llhttp__internal__n_start_req_36;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11055,7 +11274,7 @@
++           return s_n_llhttp__internal__n_start_req_40;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11080,7 +11299,7 @@
++           return s_n_llhttp__internal__n_start_req_41;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11105,7 +11324,7 @@
++           return s_n_llhttp__internal__n_start_req_42;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11130,7 +11349,7 @@
++           goto s_n_llhttp__internal__n_start_req_42;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11155,7 +11374,7 @@
++           return s_n_llhttp__internal__n_start_req_43;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11180,7 +11399,7 @@
++           return s_n_llhttp__internal__n_start_req_46;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11205,7 +11424,7 @@
++           return s_n_llhttp__internal__n_start_req_48;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11230,7 +11449,7 @@
++           return s_n_llhttp__internal__n_start_req_49;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11251,7 +11470,7 @@
++           goto s_n_llhttp__internal__n_start_req_49;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11276,7 +11495,7 @@
++           return s_n_llhttp__internal__n_start_req_50;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11301,7 +11520,7 @@
++           goto s_n_llhttp__internal__n_start_req_50;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11318,7 +11537,7 @@
++           goto s_n_llhttp__internal__n_start_req_45;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11391,7 +11610,7 @@
++           goto s_n_llhttp__internal__n_start_req_44;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_48;
+++          goto s_n_llhttp__internal__n_error_51;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11476,7 +11695,7 @@
++           goto s_n_llhttp__internal__n_res_status_start;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_42;
+++          goto s_n_llhttp__internal__n_error_45;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11556,7 +11775,7 @@
++           goto s_n_llhttp__internal__n_invoke_update_status_code;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_43;
+++          goto s_n_llhttp__internal__n_error_46;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11619,7 +11838,7 @@
++           goto s_n_llhttp__internal__n_invoke_store_http_minor_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_44;
+++          goto s_n_llhttp__internal__n_error_47;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11636,7 +11855,7 @@
++           goto s_n_llhttp__internal__n_res_http_minor;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_45;
+++          goto s_n_llhttp__internal__n_error_48;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11699,7 +11918,7 @@
++           goto s_n_llhttp__internal__n_invoke_store_http_major_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_46;
+++          goto s_n_llhttp__internal__n_error_49;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11723,7 +11942,7 @@
++           return s_n_llhttp__internal__n_start_res;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_49;
+++          goto s_n_llhttp__internal__n_error_52;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11748,7 +11967,7 @@
++           return s_n_llhttp__internal__n_req_or_res_method_2;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_47;
+++          goto s_n_llhttp__internal__n_error_50;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11772,7 +11991,7 @@
++           return s_n_llhttp__internal__n_req_or_res_method_3;
++         }
++         case kMatchMismatch: {
++-          goto s_n_llhttp__internal__n_error_47;
+++          goto s_n_llhttp__internal__n_error_50;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11793,7 +12012,7 @@
++           goto s_n_llhttp__internal__n_req_or_res_method_3;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_47;
+++          goto s_n_llhttp__internal__n_error_50;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11810,7 +12029,7 @@
++           goto s_n_llhttp__internal__n_req_or_res_method_1;
++         }
++         default: {
++-          goto s_n_llhttp__internal__n_error_47;
+++          goto s_n_llhttp__internal__n_error_50;
++         }
++       }
++       /* UNREACHABLE */;
++@@ -11870,7 +12089,7 @@
++       /* UNREACHABLE */
++       abort();
++   }
++-  s_n_llhttp__internal__n_error_36: {
+++  s_n_llhttp__internal__n_error_39: {
++     state->error = 0x7;
++     state->reason = "Invalid characters in url";
++     state->error_pos = (const char*) p;
++@@ -12314,7 +12533,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_16: {
+++  s_n_llhttp__internal__n_error_17: {
++     state->error = 0xb;
++     state->reason = "Empty Content-Length";
++     state->error_pos = (const char*) p;
++@@ -12399,14 +12618,51 @@
++   s_n_llhttp__internal__n_invoke_load_header_state: {
++     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
++       case 2:
++-        goto s_n_llhttp__internal__n_error_16;
+++        goto s_n_llhttp__internal__n_error_17;
++       default:
++         goto s_n_llhttp__internal__n_invoke_load_header_state_1;
++     }
++     /* UNREACHABLE */;
++     abort();
++   }
+++  s_n_llhttp__internal__n_error_16: {
+++    state->error = 0xa;
+++    state->reason = "Invalid header value char";
+++    state->error_pos = (const char*) p;
+++    state->_current = (void*) (intptr_t) s_error;
+++    return s_error;
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_test_flags_5: {
+++    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+++      case 1:
+++        goto s_n_llhttp__internal__n_header_value_discard_lws;
+++      default:
+++        goto s_n_llhttp__internal__n_error_16;
+++    }
+++    /* UNREACHABLE */;
+++    abort();
+++  }
++   s_n_llhttp__internal__n_invoke_update_header_state_1: {
+++    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
+++      default:
+++        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+++    }
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_load_header_state_3: {
+++    switch (llhttp__internal__c_load_header_state(state, p, endp)) {
+++      case 8:
+++        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+++      default:
+++        goto s_n_llhttp__internal__n_span_start_llhttp__on_header_value_1;
+++    }
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_update_header_state_2: {
++     switch (llhttp__internal__c_update_header_state(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_field_start;
++@@ -12417,7 +12673,7 @@
++   s_n_llhttp__internal__n_invoke_or_flags_7: {
++     switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
++       default:
++-        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+++        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
++     }
++     /* UNREACHABLE */;
++     abort();
++@@ -12425,7 +12681,7 @@
++   s_n_llhttp__internal__n_invoke_or_flags_8: {
++     switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
++       default:
++-        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+++        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
++     }
++     /* UNREACHABLE */;
++     abort();
++@@ -12433,7 +12689,7 @@
++   s_n_llhttp__internal__n_invoke_or_flags_9: {
++     switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
++       default:
++-        goto s_n_llhttp__internal__n_invoke_update_header_state_1;
+++        goto s_n_llhttp__internal__n_invoke_update_header_state_2;
++     }
++     /* UNREACHABLE */;
++     abort();
++@@ -12446,7 +12702,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_load_header_state_3: {
+++  s_n_llhttp__internal__n_invoke_load_header_state_4: {
++     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
++       case 5:
++         goto s_n_llhttp__internal__n_invoke_or_flags_7;
++@@ -12462,7 +12718,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_17: {
+++  s_n_llhttp__internal__n_error_18: {
++     state->error = 0x3;
++     state->reason = "Missing expected LF after header value";
++     state->error_pos = (const char*) p;
++@@ -12480,6 +12736,24 @@
++     err = llhttp__on_header_value(state, start, p);
++     if (err != 0) {
++       state->error = err;
+++      state->error_pos = (const char*) (p + 1);
+++      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
+++      return s_error;
+++    }
+++    p++;
+++    goto s_n_llhttp__internal__n_header_value_almost_done;
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3: {
+++    const unsigned char* start;
+++    int err;
+++    
+++    start = state->_span_pos0;
+++    state->_span_pos0 = NULL;
+++    err = llhttp__on_header_value(state, start, p);
+++    if (err != 0) {
+++      state->error = err;
++       state->error_pos = (const char*) p;
++       state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
++       return s_error;
++@@ -12488,7 +12762,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2: {
+++  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4: {
++     const unsigned char* start;
++     int err;
++     
++@@ -12506,7 +12780,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_3: {
+++  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2: {
++     const unsigned char* start;
++     int err;
++     
++@@ -12515,35 +12789,25 @@
++     err = llhttp__on_header_value(state, start, p);
++     if (err != 0) {
++       state->error = err;
++-      state->error_pos = (const char*) (p + 1);
++-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_header_value_almost_done;
+++      state->error_pos = (const char*) p;
+++      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_19;
++       return s_error;
++     }
++-    p++;
++-    goto s_n_llhttp__internal__n_header_value_almost_done;
+++    goto s_n_llhttp__internal__n_error_19;
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_18: {
++-    state->error = 0xa;
++-    state->reason = "Invalid header value char";
++-    state->error_pos = (const char*) p;
++-    state->_current = (void*) (intptr_t) s_error;
++-    return s_error;
++-    /* UNREACHABLE */;
++-    abort();
++-  }
++-  s_n_llhttp__internal__n_invoke_test_flags_5: {
+++  s_n_llhttp__internal__n_invoke_test_flags_6: {
++     switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
++       case 1:
++         goto s_n_llhttp__internal__n_header_value_lenient;
++       default:
++-        goto s_n_llhttp__internal__n_error_18;
+++        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_2;
++     }
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_update_header_state_3: {
+++  s_n_llhttp__internal__n_invoke_update_header_state_4: {
++     switch (llhttp__internal__c_update_header_state(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_value_connection;
++@@ -12554,7 +12818,7 @@
++   s_n_llhttp__internal__n_invoke_or_flags_11: {
++     switch (llhttp__internal__c_or_flags_3(state, p, endp)) {
++       default:
++-        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+++        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
++     }
++     /* UNREACHABLE */;
++     abort();
++@@ -12562,7 +12826,7 @@
++   s_n_llhttp__internal__n_invoke_or_flags_12: {
++     switch (llhttp__internal__c_or_flags_4(state, p, endp)) {
++       default:
++-        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+++        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
++     }
++     /* UNREACHABLE */;
++     abort();
++@@ -12570,7 +12834,7 @@
++   s_n_llhttp__internal__n_invoke_or_flags_13: {
++     switch (llhttp__internal__c_or_flags_5(state, p, endp)) {
++       default:
++-        goto s_n_llhttp__internal__n_invoke_update_header_state_3;
+++        goto s_n_llhttp__internal__n_invoke_update_header_state_4;
++     }
++     /* UNREACHABLE */;
++     abort();
++@@ -12583,7 +12847,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_load_header_state_4: {
+++  s_n_llhttp__internal__n_invoke_load_header_state_5: {
++     switch (llhttp__internal__c_load_header_state(state, p, endp)) {
++       case 5:
++         goto s_n_llhttp__internal__n_invoke_or_flags_11;
++@@ -12599,39 +12863,39 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_update_header_state_4: {
++-    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+++  s_n_llhttp__internal__n_invoke_update_header_state_5: {
+++    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_value_connection_token;
++     }
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_update_header_state_2: {
++-    switch (llhttp__internal__c_update_header_state_2(state, p, endp)) {
+++  s_n_llhttp__internal__n_invoke_update_header_state_3: {
+++    switch (llhttp__internal__c_update_header_state_3(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_value_connection_ws;
++     }
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_update_header_state_5: {
++-    switch (llhttp__internal__c_update_header_state_5(state, p, endp)) {
+++  s_n_llhttp__internal__n_invoke_update_header_state_6: {
+++    switch (llhttp__internal__c_update_header_state_6(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_value_connection_ws;
++     }
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_update_header_state_6: {
++-    switch (llhttp__internal__c_update_header_state_6(state, p, endp)) {
+++  s_n_llhttp__internal__n_invoke_update_header_state_7: {
+++    switch (llhttp__internal__c_update_header_state_7(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_value_connection_ws;
++     }
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4: {
+++  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5: {
++     const unsigned char* start;
++     int err;
++     
++@@ -12641,17 +12905,17 @@
++     if (err != 0) {
++       state->error = err;
++       state->error_pos = (const char*) p;
++-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_20;
+++      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_21;
++       return s_error;
++     }
++-    goto s_n_llhttp__internal__n_error_20;
+++    goto s_n_llhttp__internal__n_error_21;
++     /* UNREACHABLE */;
++     abort();
++   }
++   s_n_llhttp__internal__n_invoke_mul_add_content_length_1: {
++     switch (llhttp__internal__c_mul_add_content_length_1(state, p, endp, match)) {
++       case 1:
++-        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_4;
+++        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5;
++       default:
++         goto s_n_llhttp__internal__n_header_value_content_length;
++     }
++@@ -12666,7 +12930,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_5: {
+++  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_6: {
++     const unsigned char* start;
++     int err;
++     
++@@ -12676,14 +12940,14 @@
++     if (err != 0) {
++       state->error = err;
++       state->error_pos = (const char*) p;
++-      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_21;
+++      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_22;
++       return s_error;
++     }
++-    goto s_n_llhttp__internal__n_error_21;
+++    goto s_n_llhttp__internal__n_error_22;
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_19: {
+++  s_n_llhttp__internal__n_error_20: {
++     state->error = 0x4;
++     state->reason = "Duplicate Content-Length";
++     state->error_pos = (const char*) p;
++@@ -12692,26 +12956,82 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_test_flags_6: {
++-    switch (llhttp__internal__c_test_flags_6(state, p, endp)) {
+++  s_n_llhttp__internal__n_invoke_test_flags_7: {
+++    switch (llhttp__internal__c_test_flags_7(state, p, endp)) {
++       case 0:
++         goto s_n_llhttp__internal__n_header_value_content_length;
++       default:
++-        goto s_n_llhttp__internal__n_error_19;
+++        goto s_n_llhttp__internal__n_error_20;
++     }
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_update_header_state_7: {
++-    switch (llhttp__internal__c_update_header_state_7(state, p, endp)) {
+++  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_8: {
+++    const unsigned char* start;
+++    int err;
+++    
+++    start = state->_span_pos0;
+++    state->_span_pos0 = NULL;
+++    err = llhttp__on_header_value(state, start, p);
+++    if (err != 0) {
+++      state->error = err;
+++      state->error_pos = (const char*) (p + 1);
+++      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_24;
+++      return s_error;
+++    }
+++    p++;
+++    goto s_n_llhttp__internal__n_error_24;
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_update_header_state_8: {
+++    switch (llhttp__internal__c_update_header_state_8(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_value_otherwise;
++     }
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_update_header_state_8: {
++-    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+++  s_n_llhttp__internal__n_span_end_llhttp__on_header_value_7: {
+++    const unsigned char* start;
+++    int err;
+++    
+++    start = state->_span_pos0;
+++    state->_span_pos0 = NULL;
+++    err = llhttp__on_header_value(state, start, p);
+++    if (err != 0) {
+++      state->error = err;
+++      state->error_pos = (const char*) (p + 1);
+++      state->_current = (void*) (intptr_t) s_n_llhttp__internal__n_error_23;
+++      return s_error;
+++    }
+++    p++;
+++    goto s_n_llhttp__internal__n_error_23;
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_test_flags_9: {
+++    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+++      case 0:
+++        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_7;
+++      default:
+++        goto s_n_llhttp__internal__n_header_value_te_chunked;
+++    }
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_load_type_1: {
+++    switch (llhttp__internal__c_load_type(state, p, endp)) {
+++      case 1:
+++        goto s_n_llhttp__internal__n_invoke_test_flags_9;
+++      default:
+++        goto s_n_llhttp__internal__n_header_value_te_chunked;
+++    }
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_update_header_state_9: {
+++    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_value;
++     }
++@@ -12726,6 +13046,34 @@
++     /* UNREACHABLE */;
++     abort();
++   }
+++  s_n_llhttp__internal__n_invoke_or_flags_17: {
+++    switch (llhttp__internal__c_or_flags_16(state, p, endp)) {
+++      default:
+++        goto s_n_llhttp__internal__n_invoke_and_flags;
+++    }
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_test_flags_10: {
+++    switch (llhttp__internal__c_test_flags_2(state, p, endp)) {
+++      case 0:
+++        goto s_n_llhttp__internal__n_span_end_llhttp__on_header_value_8;
+++      default:
+++        goto s_n_llhttp__internal__n_invoke_or_flags_17;
+++    }
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_load_type_2: {
+++    switch (llhttp__internal__c_load_type(state, p, endp)) {
+++      case 1:
+++        goto s_n_llhttp__internal__n_invoke_test_flags_10;
+++      default:
+++        goto s_n_llhttp__internal__n_invoke_or_flags_17;
+++    }
+++    /* UNREACHABLE */;
+++    abort();
+++  }
++   s_n_llhttp__internal__n_invoke_or_flags_16: {
++     switch (llhttp__internal__c_or_flags_16(state, p, endp)) {
++       default:
++@@ -12734,10 +13082,20 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_or_flags_17: {
++-    switch (llhttp__internal__c_or_flags_17(state, p, endp)) {
+++  s_n_llhttp__internal__n_invoke_test_flags_8: {
+++    switch (llhttp__internal__c_test_flags_8(state, p, endp)) {
+++      case 1:
+++        goto s_n_llhttp__internal__n_invoke_load_type_2;
++       default:
++-        goto s_n_llhttp__internal__n_invoke_update_header_state_8;
+++        goto s_n_llhttp__internal__n_invoke_or_flags_16;
+++    }
+++    /* UNREACHABLE */;
+++    abort();
+++  }
+++  s_n_llhttp__internal__n_invoke_or_flags_18: {
+++    switch (llhttp__internal__c_or_flags_18(state, p, endp)) {
+++      default:
+++        goto s_n_llhttp__internal__n_invoke_update_header_state_9;
++     }
++     /* UNREACHABLE */;
++     abort();
++@@ -12747,11 +13105,11 @@
++       case 1:
++         goto s_n_llhttp__internal__n_header_value_connection;
++       case 2:
++-        goto s_n_llhttp__internal__n_invoke_test_flags_6;
+++        goto s_n_llhttp__internal__n_invoke_test_flags_7;
++       case 3:
++-        goto s_n_llhttp__internal__n_invoke_or_flags_16;
+++        goto s_n_llhttp__internal__n_invoke_test_flags_8;
++       case 4:
++-        goto s_n_llhttp__internal__n_invoke_or_flags_17;
+++        goto s_n_llhttp__internal__n_invoke_or_flags_18;
++       default:
++         goto s_n_llhttp__internal__n_header_value;
++     }
++@@ -12794,7 +13152,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_22: {
+++  s_n_llhttp__internal__n_error_25: {
++     state->error = 0xa;
++     state->reason = "Invalid header token";
++     state->error_pos = (const char*) p;
++@@ -12803,8 +13161,8 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_update_header_state_9: {
++-    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+++  s_n_llhttp__internal__n_invoke_update_header_state_10: {
+++    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_field_general;
++     }
++@@ -12819,8 +13177,8 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_invoke_update_header_state_10: {
++-    switch (llhttp__internal__c_update_header_state_4(state, p, endp)) {
+++  s_n_llhttp__internal__n_invoke_update_header_state_11: {
+++    switch (llhttp__internal__c_update_header_state_1(state, p, endp)) {
++       default:
++         goto s_n_llhttp__internal__n_header_field_general;
++     }
++@@ -12860,7 +13218,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_23: {
+++  s_n_llhttp__internal__n_error_26: {
++     state->error = 0x7;
++     state->reason = "Expected CRLF";
++     state->error_pos = (const char*) p;
++@@ -12886,7 +13244,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_24: {
+++  s_n_llhttp__internal__n_error_27: {
++     state->error = 0x9;
++     state->reason = "Expected CRLF after version";
++     state->error_pos = (const char*) p;
++@@ -12903,7 +13261,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_25: {
+++  s_n_llhttp__internal__n_error_28: {
++     state->error = 0x9;
++     state->reason = "Invalid minor version";
++     state->error_pos = (const char*) p;
++@@ -12912,7 +13270,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_26: {
+++  s_n_llhttp__internal__n_error_29: {
++     state->error = 0x9;
++     state->reason = "Expected dot";
++     state->error_pos = (const char*) p;
++@@ -12929,7 +13287,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_27: {
+++  s_n_llhttp__internal__n_error_30: {
++     state->error = 0x9;
++     state->reason = "Invalid major version";
++     state->error_pos = (const char*) p;
++@@ -12938,7 +13296,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_29: {
+++  s_n_llhttp__internal__n_error_32: {
++     state->error = 0x8;
++     state->reason = "Expected HTTP/";
++     state->error_pos = (const char*) p;
++@@ -12947,7 +13305,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_28: {
+++  s_n_llhttp__internal__n_error_31: {
++     state->error = 0x8;
++     state->reason = "Expected SOURCE method for ICE/x.x request";
++     state->error_pos = (const char*) p;
++@@ -12959,7 +13317,7 @@
++   s_n_llhttp__internal__n_invoke_is_equal_method_1: {
++     switch (llhttp__internal__c_is_equal_method_1(state, p, endp)) {
++       case 0:
++-        goto s_n_llhttp__internal__n_error_28;
+++        goto s_n_llhttp__internal__n_error_31;
++       default:
++         goto s_n_llhttp__internal__n_req_http_major;
++     }
++@@ -13034,7 +13392,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_30: {
+++  s_n_llhttp__internal__n_error_33: {
++     state->error = 0x7;
++     state->reason = "Invalid char in url fragment start";
++     state->error_pos = (const char*) p;
++@@ -13094,7 +13452,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_31: {
+++  s_n_llhttp__internal__n_error_34: {
++     state->error = 0x7;
++     state->reason = "Invalid char in url query";
++     state->error_pos = (const char*) p;
++@@ -13103,7 +13461,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_32: {
+++  s_n_llhttp__internal__n_error_35: {
++     state->error = 0x7;
++     state->reason = "Invalid char in url path";
++     state->error_pos = (const char*) p;
++@@ -13214,7 +13572,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_33: {
+++  s_n_llhttp__internal__n_error_36: {
++     state->error = 0x7;
++     state->reason = "Double @ in url";
++     state->error_pos = (const char*) p;
++@@ -13223,7 +13581,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_34: {
+++  s_n_llhttp__internal__n_error_37: {
++     state->error = 0x7;
++     state->reason = "Unexpected char in url server";
++     state->error_pos = (const char*) p;
++@@ -13232,7 +13590,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_35: {
+++  s_n_llhttp__internal__n_error_38: {
++     state->error = 0x7;
++     state->reason = "Unexpected char in url server";
++     state->error_pos = (const char*) p;
++@@ -13241,7 +13599,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_37: {
+++  s_n_llhttp__internal__n_error_40: {
++     state->error = 0x7;
++     state->reason = "Unexpected char in url schema";
++     state->error_pos = (const char*) p;
++@@ -13250,7 +13608,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_38: {
+++  s_n_llhttp__internal__n_error_41: {
++     state->error = 0x7;
++     state->reason = "Unexpected char in url schema";
++     state->error_pos = (const char*) p;
++@@ -13259,7 +13617,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_39: {
+++  s_n_llhttp__internal__n_error_42: {
++     state->error = 0x7;
++     state->reason = "Unexpected start char in url";
++     state->error_pos = (const char*) p;
++@@ -13278,7 +13636,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_40: {
+++  s_n_llhttp__internal__n_error_43: {
++     state->error = 0x6;
++     state->reason = "Expected space after method";
++     state->error_pos = (const char*) p;
++@@ -13295,7 +13653,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_48: {
+++  s_n_llhttp__internal__n_error_51: {
++     state->error = 0x6;
++     state->reason = "Invalid method encountered";
++     state->error_pos = (const char*) p;
++@@ -13304,7 +13662,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_41: {
+++  s_n_llhttp__internal__n_error_44: {
++     state->error = 0xd;
++     state->reason = "Response overflow";
++     state->error_pos = (const char*) p;
++@@ -13316,7 +13674,7 @@
++   s_n_llhttp__internal__n_invoke_mul_add_status_code: {
++     switch (llhttp__internal__c_mul_add_status_code(state, p, endp, match)) {
++       case 1:
++-        goto s_n_llhttp__internal__n_error_41;
+++        goto s_n_llhttp__internal__n_error_44;
++       default:
++         goto s_n_llhttp__internal__n_res_status_code;
++     }
++@@ -13359,7 +13717,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_42: {
+++  s_n_llhttp__internal__n_error_45: {
++     state->error = 0xd;
++     state->reason = "Invalid response status";
++     state->error_pos = (const char*) p;
++@@ -13376,7 +13734,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_43: {
+++  s_n_llhttp__internal__n_error_46: {
++     state->error = 0x9;
++     state->reason = "Expected space after version";
++     state->error_pos = (const char*) p;
++@@ -13393,7 +13751,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_44: {
+++  s_n_llhttp__internal__n_error_47: {
++     state->error = 0x9;
++     state->reason = "Invalid minor version";
++     state->error_pos = (const char*) p;
++@@ -13402,7 +13760,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_45: {
+++  s_n_llhttp__internal__n_error_48: {
++     state->error = 0x9;
++     state->reason = "Expected dot";
++     state->error_pos = (const char*) p;
++@@ -13419,7 +13777,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_46: {
+++  s_n_llhttp__internal__n_error_49: {
++     state->error = 0x9;
++     state->reason = "Invalid major version";
++     state->error_pos = (const char*) p;
++@@ -13428,7 +13786,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_49: {
+++  s_n_llhttp__internal__n_error_52: {
++     state->error = 0x8;
++     state->reason = "Expected HTTP/";
++     state->error_pos = (const char*) p;
++@@ -13453,7 +13811,7 @@
++     /* UNREACHABLE */;
++     abort();
++   }
++-  s_n_llhttp__internal__n_error_47: {
+++  s_n_llhttp__internal__n_error_50: {
++     state->error = 0x8;
++     state->reason = "Invalid word encountered";
++     state->error_pos = (const char*) p;
++--- nodejs-12.22.12~dfsg/test/parallel/test-http-invalid-te.js
+++++ nodejs-12.22.12~dfsg/test/parallel/test-http-invalid-te.js
++@@ -13,7 +13,7 @@ Content-Type: text/plain; charset=utf-8
++ Host: hacker.exploit.com
++ Connection: keep-alive
++ Content-Length: 10
++-Transfer-Encoding: chunked, eee
+++Transfer-Encoding: eee, chunked
++ 
++ HELLOWORLDPOST / HTTP/1.1
++ Content-Type: text/plain; charset=utf-8
++--- nodejs-12.22.12~dfsg/test/parallel/test-http-missing-header-separator-cr.js
+++++ nodejs-12.22.12~dfsg/test/parallel/test-http-missing-header-separator-cr.js
++@@ -0,0 +1,83 @@
+++'use strict';
+++
+++const common = require('../common');
+++const assert = require('assert');
+++
+++const http = require('http');
+++const net = require('net');
+++
+++function serverHandler(server, msg) {
+++  const client = net.connect(server.address().port, 'localhost');
+++
+++  let response = '';
+++
+++  client.on('data', common.mustCall((chunk) => {
+++    response += chunk.toString('utf-8');
+++  }));
+++
+++  client.setEncoding('utf8');
+++  client.on('error', common.mustNotCall());
+++  client.on('end', common.mustCall(() => {
+++    assert.strictEqual(
+++      response,
+++      'HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n'
+++    );
+++    server.close();
+++  }));
+++  client.write(msg);
+++  client.resume();
+++}
+++
+++{
+++  const msg = [
+++    'GET / HTTP/1.1',
+++    'Host: localhost',
+++    'Dummy: x\nContent-Length: 23',
+++    '',
+++    'GET / HTTP/1.1',
+++    'Dummy: GET /admin HTTP/1.1',
+++    'Host: localhost',
+++    '',
+++    '',
+++  ].join('\r\n');
+++
+++  const server = http.createServer(common.mustNotCall());
+++
+++  server.listen(0, common.mustCall(serverHandler.bind(null, server, msg)));
+++}
+++
+++{
+++  const msg = [
+++    'POST / HTTP/1.1',
+++    'Host: localhost',
+++    'x:x\nTransfer-Encoding: chunked',
+++    '',
+++    '1',
+++    'A',
+++    '0',
+++    '',
+++    '',
+++  ].join('\r\n');
+++
+++  const server = http.createServer(common.mustNotCall());
+++
+++  server.listen(0, common.mustCall(serverHandler.bind(null, server, msg)));
+++}
+++
+++{
+++  const msg = [
+++    'POST / HTTP/1.1',
+++    'Host: localhost',
+++    'x:\nTransfer-Encoding: chunked',
+++    '',
+++    '1',
+++    'A',
+++    '0',
+++    '',
+++    '',
+++  ].join('\r\n');
+++
+++  const server = http.createServer(common.mustNotCall());
+++
+++  server.listen(0, common.mustCall(serverHandler.bind(null, server, msg)));
+++}
++--- /dev/null
+++++ nodejs-12.22.12~dfsg/test/parallel/test-http-transfer-encoding-repeated-chunked.js
++@@ -0,0 +1,51 @@
+++'use strict';
+++
+++const common = require('../common');
+++const assert = require('assert');
+++
+++const http = require('http');
+++const net = require('net');
+++
+++const msg = [
+++  'POST / HTTP/1.1',
+++  'Host: 127.0.0.1',
+++  'Transfer-Encoding: chunkedchunked',
+++  '',
+++  '1',
+++  'A',
+++  '0',
+++  '',
+++].join('\r\n');
+++
+++const server = http.createServer(common.mustCall((req, res) => {
+++  // Verify that no data is received
+++
+++  req.on('data', common.mustNotCall());
+++
+++  req.on('end', common.mustNotCall(() => {
+++    res.writeHead(200, { 'Content-Type': 'text/plain' });
+++    res.end();
+++  }));
+++}, 1));
+++
+++server.listen(0, common.mustCall(() => {
+++  const client = net.connect(server.address().port, 'localhost');
+++
+++  let response = '';
+++
+++  client.on('data', common.mustCall((chunk) => {
+++    response += chunk.toString('utf-8');
+++  }));
+++
+++  client.setEncoding('utf8');
+++  client.on('error', common.mustNotCall());
+++  client.on('end', common.mustCall(() => {
+++    assert.strictEqual(
+++      response,
+++      'HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n'
+++    );
+++    server.close();
+++  }));
+++  client.write(msg);
+++  client.resume();
+++}));
++--- nodejs-12.22.12~dfsg/test/parallel/test-http-transfer-encoding-smuggling.js
+++++ nodejs-12.22.12~dfsg/test/parallel/test-http-transfer-encoding-smuggling.js
++@@ -1,46 +1,89 @@
++ 'use strict';
++ 
++ const common = require('../common');
++-
++ const assert = require('assert');
+++
++ const http = require('http');
++ const net = require('net');
++ 
++-const msg = [
++-  'POST / HTTP/1.1',
++-  'Host: 127.0.0.1',
++-  'Transfer-Encoding: chunked',
++-  'Transfer-Encoding: chunked-false',
++-  'Connection: upgrade',
++-  '',
++-  '1',
++-  'A',
++-  '0',
++-  '',
++-  'GET /flag HTTP/1.1',
++-  'Host: 127.0.0.1',
++-  '',
++-  '',
++-].join('\r\n');
++-
++-// Verify that the server is called only once even with a smuggled request.
++-
++-const server = http.createServer(common.mustCall((req, res) => {
++-  res.end();
++-}, 1));
++-
++-function send(next) {
++-  const client = net.connect(server.address().port, 'localhost');
++-  client.setEncoding('utf8');
++-  client.on('error', common.mustNotCall());
++-  client.on('end', next);
++-  client.write(msg);
++-  client.resume();
+++{
+++  const msg = [
+++    'POST / HTTP/1.1',
+++    'Host: 127.0.0.1',
+++    'Transfer-Encoding: chunked',
+++    'Transfer-Encoding: chunked-false',
+++    'Connection: upgrade',
+++    '',
+++    '1',
+++    'A',
+++    '0',
+++    '',
+++    'GET /flag HTTP/1.1',
+++    'Host: 127.0.0.1',
+++    '',
+++    '',
+++  ].join('\r\n');
+++
+++  const server = http.createServer(common.mustNotCall((req, res) => {
+++    res.end();
+++  }, 1));
+++
+++  server.listen(0, common.mustCall(() => {
+++    const client = net.connect(server.address().port, 'localhost');
+++
+++    let response = '';
+++
+++    // Verify that the server listener is never called
+++
+++    client.on('data', common.mustCall((chunk) => {
+++      response += chunk.toString('utf-8');
+++    }));
+++
+++    client.setEncoding('utf8');
+++    client.on('error', common.mustNotCall());
+++    client.on('end', common.mustCall(() => {
+++      assert.strictEqual(
+++        response,
+++        'HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n'
+++      );
+++      server.close();
+++    }));
+++    client.write(msg);
+++    client.resume();
+++  }));
++ }
++ 
++-server.listen(0, common.mustCall((err) => {
++-  assert.ifError(err);
++-  send(common.mustCall(() => {
++-    server.close();
+++{
+++  const msg = [
+++    'POST / HTTP/1.1',
+++    'Host: 127.0.0.1',
+++    'Transfer-Encoding: chunked',
+++    ' , chunked-false',
+++    'Connection: upgrade',
+++    '',
+++    '1',
+++    'A',
+++    '0',
+++    '',
+++    'GET /flag HTTP/1.1',
+++    'Host: 127.0.0.1',
+++    '',
+++    '',
+++  ].join('\r\n');
+++
+++  const server = http.createServer(common.mustCall((request, response) => {
+++    assert.notStrictEqual(request.url, '/admin');
+++    response.end('hello world');
+++  }), 1);
+++
+++  server.listen(0, common.mustCall(() => {
+++    const client = net.connect(server.address().port, 'localhost');
+++
+++    client.on('end', common.mustCall(function() {
+++      server.close();
+++    }));
+++
+++    client.write(msg);
+++    client.resume();
++   }));
++-}));
+++}
++--- nodejs-12.22.12~dfsg/test/parallel/test-http-header-overflow.js
+++++ nodejs-12.22.12~dfsg/test/parallel/test-http-header-overflow.js
++@@ -1,3 +1,5 @@
+++// Flags: --expose-internals
+++
++ 'use strict';
++ const { expectsError, mustCall } = require('../common');
++ const assert = require('assert');
++@@ -8,7 +10,7 @@ const CRLF = '\r\n';
++ const DUMMY_HEADER_NAME = 'Cookie: ';
++ const DUMMY_HEADER_VALUE = 'a'.repeat(
++   // Plus one is to make it 1 byte too big
++-  maxHeaderSize - DUMMY_HEADER_NAME.length - (2 * CRLF.length) + 1
+++  maxHeaderSize - DUMMY_HEADER_NAME.length + 2
++ );
++ const PAYLOAD_GET = 'GET /blah HTTP/1.1';
++ const PAYLOAD = PAYLOAD_GET + CRLF +
++@@ -21,7 +23,7 @@ server.on('connection', mustCall((socket
++     name: 'Error',
++     message: 'Parse Error: Header overflow',
++     code: 'HPE_HEADER_OVERFLOW',
++-    bytesParsed: maxHeaderSize + PAYLOAD_GET.length,
+++    bytesParsed: maxHeaderSize + PAYLOAD_GET.length + (CRLF.length * 2) + 1,
++     rawPacket: Buffer.from(PAYLOAD)
++   }));
++ }));
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/gcc13.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/gcc13.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/gcc13.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/gcc13.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,63 @@
++From 576aed71db7b40c90b44c623580629792a606928 Mon Sep 17 00:00:00 2001
++From: Jiawen Geng <technicalcute@gmail.com>
++Date: Fri, 14 Oct 2022 09:54:33 +0800
++Subject: [PATCH] deps: V8: cherry-pick c2792e58035f
++MIME-Version: 1.0
++Content-Type: text/plain; charset=UTF-8
++Content-Transfer-Encoding: 8bit
++
++Original commit message:
++
++    [base] Fix build with gcc-13
++
++    See https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes.
++
++    Also see Gentoo Linux bug report: https://bugs.gentoo.org/865981
++
++    Change-Id: I421f396b02ba37e12ee70048ee33e034f8113566
++    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3934140
++    Reviewed-by: Clemens Backes <clemensb@chromium.org>
++    Reviewed-by: Simon Zund <szuend@chromium.org>
++    Commit-Queue: Clemens Backes <clemensb@chromium.org>
++    Cr-Commit-Position: refs/heads/main@{#83587}
++
++Refs: https://github.com/v8/v8/commit/c2792e58035fcbaa16d0cb70998852fbeb5df4cc
++PR-URL: https://github.com/nodejs/node/pull/44961
++Fixes: https://github.com/nodejs/node/issues/43642
++Reviewed-By: Michael Zasso <targos@protonmail.com>
++Reviewed-By: Richard Lau <rlau@redhat.com>
++Reviewed-By: Luigi Pinca <luigipinca@gmail.com>
++Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
++
++Upstream-Status: Backport [https://github.com/nodejs/node/commit/0be1c5728173ea9ac42843058e26b6268568acf0]
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++---
++ deps/v8/AUTHORS                               | 1 +
++ deps/v8/src/base/logging.h                    | 1 +
++ deps/v8/src/inspector/v8-string-conversions.h | 1 +
++ 3 files changed, 3 insertions(+)
++
++diff --git a/deps/v8/src/base/logging.h b/deps/v8/src/base/logging.h
++index 08db24a9..38be165f 100644
++--- a/deps/v8/src/base/logging.h
+++++ b/deps/v8/src/base/logging.h
++@@ -5,6 +5,7 @@
++ #ifndef V8_BASE_LOGGING_H_
++ #define V8_BASE_LOGGING_H_
++ 
+++#include <cstdint>
++ #include <cstring>
++ #include <sstream>
++ #include <string>
++diff --git a/deps/v8/src/inspector/v8-string-conversions.h b/deps/v8/src/inspector/v8-string-conversions.h
++index c1d69c18..eb33c681 100644
++--- a/deps/v8/src/inspector/v8-string-conversions.h
+++++ b/deps/v8/src/inspector/v8-string-conversions.h
++@@ -5,6 +5,7 @@
++ #ifndef V8_INSPECTOR_V8_STRING_CONVERSIONS_H_
++ #define V8_INSPECTOR_V8_STRING_CONVERSIONS_H_
++ 
+++#include <cstdint>
++ #include <string>
++ 
++ // Conversion routines between UT8 and UTF16, used by string-16.{h,cc}. You may
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/libatomic-nodejs14.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/libatomic-nodejs14.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/libatomic-nodejs14.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/libatomic-nodejs14.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,21 @@
++Link mksnapshot with libatomic on x86
++
++Clang-12 on x86 emits atomic builtins
++
++Fixes
++| module-compiler.cc:(.text._ZN2v88internal4wasm12_GLOBAL__N_123ExecuteCompilationUnitsERKSt10shared_ptrINS2_22BackgroundCompileTokenEEPNS0_8CountersEiNS2_19CompileBaselineOnlyE+0x558): un
++defined reference to `__atomic_load'
++
++Upstream-Status: Pending
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++
++--- a/tools/v8_gypfiles/v8.gyp
+++++ b/tools/v8_gypfiles/v8.gyp
++@@ -1336,6 +1336,7 @@
++     {
++       'target_name': 'mksnapshot',
++       'type': 'executable',
+++      'libraries': [ '-latomic' ],
++       'dependencies': [
++         'v8_base_without_compiler',
++         'v8_compiler_for_mksnapshot',
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/mips-less-memory-nodejs14.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/mips-less-memory-nodejs14.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/mips-less-memory-nodejs14.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/mips-less-memory-nodejs14.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,32 @@
++Description: mksnapshot uses too much memory on 32-bit mipsel
++Author: Jérémy Lal <kapouer@melix.org>
++Last-Update: 2020-06-03
++Forwarded: https://bugs.chromium.org/p/v8/issues/detail?id=10586
++
++This ensures that we reserve 500M instead of 2G range for codegen
++ensures that qemu-mips can allocate such large ranges
++
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++
++--- a/deps/v8/src/common/globals.h
+++++ b/deps/v8/src/common/globals.h
++@@ -224,7 +224,7 @@ constexpr size_t kMinimumCodeRangeSize =
++ constexpr size_t kMinExpectedOSPageSize = 64 * KB;  // OS page on PPC Linux
++ #elif V8_TARGET_ARCH_MIPS
++ constexpr bool kPlatformRequiresCodeRange = false;
++-constexpr size_t kMaximalCodeRangeSize = 2048LL * MB;
+++constexpr size_t kMaximalCodeRangeSize = 512 * MB;
++ constexpr size_t kMinimumCodeRangeSize = 0 * MB;
++ constexpr size_t kMinExpectedOSPageSize = 4 * KB;  // OS page.
++ #else
++--- a/deps/v8/src/codegen/mips/constants-mips.h
+++++ b/deps/v8/src/codegen/mips/constants-mips.h
++@@ -140,7 +140,7 @@ const uint32_t kLeastSignificantByteInIn
++ namespace v8 {
++ namespace internal {
++
++-constexpr size_t kMaxPCRelativeCodeRangeInMB = 4096;
+++constexpr size_t kMaxPCRelativeCodeRangeInMB = 1024;
++
++ // -----------------------------------------------------------------------------
++ // Registers and FPURegisters.
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/mips-warnings.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/mips-warnings.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/mips-warnings.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/mips-warnings.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,19 @@
++Add explicit static cast to fix narrowing warning
++
++Fixes
++deps/v8/src/codegen/mips/assembler-mips.cc:3556:44: error: non-constant-expression cannot be narrowed from type 'int' to 'size_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
++
++Upstream-Status: Pending
++
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++--- a/deps/v8/src/codegen/mips/assembler-mips.cc
+++++ b/deps/v8/src/codegen/mips/assembler-mips.cc
++@@ -3553,7 +3553,7 @@ void Assembler::GrowBuffer() {
++                                reloc_info_writer.last_pc() + pc_delta);
++ 
++   // Relocate runtime entries.
++-  Vector<byte> instructions{buffer_start_, pc_offset()};
+++  Vector<byte> instructions{buffer_start_, static_cast<size_t>(pc_offset())};
++   Vector<const byte> reloc_info{reloc_info_writer.pos(), reloc_size};
++   for (RelocIterator it(instructions, reloc_info, 0); !it.done(); it.next()) {
++     RelocInfo::Mode rmode = it.rinfo()->rmode();
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/python-3.11-invalid-mode-rU.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/python-3.11-invalid-mode-rU.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/python-3.11-invalid-mode-rU.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs/python-3.11-invalid-mode-rU.patch	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,46 @@
++From e4d6f2e4091a4c7b6f3281be0e281b32ee6e5a33 Mon Sep 17 00:00:00 2001
++From: Christian Clauss <cclauss@me.com>
++Date: Thu, 26 Nov 2020 12:39:11 +0100
++Subject: [PATCH] Fix ValueError: invalid mode: 'rU' while trying to load
++ binding.gyp
++
++Fixes nodejs/node-gyp#2219
++File mode `U` is deprecated in Python 3 https://docs.python.org/3/library/functions.html#open
++https://github.com/asottile/pyupgrade#redundant-open-modes
++
++Upstream-Status: Backport [https://github.com/nodejs/gyp-next/commit/3f8cb33ea4d191df41f4fb7a1dfbd302507f7260]
++Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
++---
++ deps/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py | 2 +-
++ tools/gyp/pylib/gyp/input.py                          | 2 +-
++ 2 files changed, 2 insertions(+), 2 deletions(-)
++
++diff --git a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py
++index d174280..2f34bc0 100644
++--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py
+++++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py
++@@ -226,7 +226,7 @@ def LoadOneBuildFile(build_file_path, data, aux_data, includes,
++     # Open the build file for read ('r') with universal-newlines mode ('U')
++     # to make sure platform specific newlines ('\r\n' or '\r') are converted to '\n'
++     # which otherwise will fail eval()
++-    if sys.platform == 'zos':
+++    if PY3 or sys.platform == 'zos':
++       # On z/OS, universal-newlines mode treats the file as an ascii file. But since
++       # node-gyp produces ebcdic files, do not use that mode.
++       build_file_contents = open(build_file_path, 'r').read()
++diff --git a/tools/gyp/pylib/gyp/input.py b/tools/gyp/pylib/gyp/input.py
++index 1f40abb..fd12e78 100644
++--- a/tools/gyp/pylib/gyp/input.py
+++++ b/tools/gyp/pylib/gyp/input.py
++@@ -226,7 +226,7 @@ def LoadOneBuildFile(build_file_path, data, aux_data, includes,
++     # Open the build file for read ('r') with universal-newlines mode ('U')
++     # to make sure platform specific newlines ('\r\n' or '\r') are converted to '\n'
++     # which otherwise will fail eval()
++-    if sys.platform == 'zos':
+++    if PY3 or sys.platform == 'zos':
++       # On z/OS, universal-newlines mode treats the file as an ascii file. But since
++       # node-gyp produces ebcdic files, do not use that mode.
++       build_file_contents = open(build_file_path, 'r').read()
++-- 
++2.38.1
++
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs_12.22.12.bb b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs_12.22.12.bb
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs_12.22.12.bb	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs_12.22.12.bb	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,167 @@
++DESCRIPTION = "nodeJS Evented I/O for V8 JavaScript"
++HOMEPAGE = "http://nodejs.org"
++LICENSE = "MIT & BSD & Artistic-2.0"
++LIC_FILES_CHKSUM = "file://LICENSE;md5=93997aa7a45ba0f25f9c61aaab153ab8"
++
++DEPENDS = "openssl"
++DEPENDS_append_class-target = " nodejs-native"
++
++inherit pkgconfig python3native
++
++COMPATIBLE_MACHINE_armv4 = "(!.*armv4).*"
++COMPATIBLE_MACHINE_armv5 = "(!.*armv5).*"
++COMPATIBLE_MACHINE_mips64 = "(!.*mips64).*"
++
++COMPATIBLE_HOST_riscv64 = "null"
++COMPATIBLE_HOST_riscv32 = "null"
++
++SRC_URI = "http://nodejs.org/dist/v${PV}/node-v${PV}.tar.xz \
++           file://0001-Disable-running-gyp-files-for-bundled-deps.patch \
++           file://0003-Install-both-binaries-and-use-libdir.patch \
++           file://0004-v8-don-t-override-ARM-CFLAGS.patch \
++           file://big-endian.patch \
++           file://mips-warnings.patch \
++           file://0001-Remove-use-of-register-r7-because-llvm-now-issues-an.patch \
++           file://CVE-2022-32212.patch \
++           file://CVE-2022-35255.patch \
++           file://CVE-2022-43548.patch \
++           file://CVE-llhttp.patch \
++           file://python-3.11-invalid-mode-rU.patch \
++           file://gcc13.patch \
++           "
++SRC_URI_append_class-target = " \
++           file://0002-Using-native-binaries.patch \
++           "
++SRC_URI[sha256sum] = "bc42b7f8495b9bfc7f7850dd180bb02a5bdf139cc232b8c6f02a6967e20714f2"
++
++S = "${WORKDIR}/node-v${PV}"
++
++# v8 errors out if you have set CCACHE
++CCACHE = ""
++
++def map_nodejs_arch(a, d):
++    import re
++
++    if   re.match('i.86$', a): return 'ia32'
++    elif re.match('x86_64$', a): return 'x64'
++    elif re.match('aarch64$', a): return 'arm64'
++    elif re.match('(powerpc64|ppc64le)$', a): return 'ppc64'
++    elif re.match('powerpc$', a): return 'ppc'
++    return a
++
++ARCHFLAGS_arm = "${@bb.utils.contains('TUNE_FEATURES', 'callconvention-hard', '--with-arm-float-abi=hard', '--with-arm-float-abi=softfp', d)} \
++                 ${@bb.utils.contains('TUNE_FEATURES', 'neon', '--with-arm-fpu=neon', \
++                    bb.utils.contains('TUNE_FEATURES', 'vfpv3d16', '--with-arm-fpu=vfpv3-d16', \
++                    bb.utils.contains('TUNE_FEATURES', 'vfpv3', '--with-arm-fpu=vfpv3', \
++                    '--with-arm-fpu=vfp', d), d), d)}"
++GYP_DEFINES_append_mipsel = " mips_arch_variant='r1' "
++ARCHFLAGS ?= ""
++
++PACKAGECONFIG ??= "ares brotli icu zlib"
++
++PACKAGECONFIG[ares] = "--shared-cares,,c-ares"
++PACKAGECONFIG[brotli] = "--shared-brotli,,brotli"
++PACKAGECONFIG[icu] = "--with-intl=system-icu,--without-intl,icu"
++PACKAGECONFIG[libuv] = "--shared-libuv,,libuv"
++PACKAGECONFIG[nghttp2] = "--shared-nghttp2,,nghttp2"
++PACKAGECONFIG[shared] = "--shared"
++PACKAGECONFIG[zlib] = "--shared-zlib,,zlib"
++
++# We don't want to cross-compile during target compile,
++# and we need to use the right flags during host compile,
++# too.
++EXTRA_OEMAKE = "\
++    CC.host='${CC}' \
++    CFLAGS.host='${CPPFLAGS} ${CFLAGS}' \
++    CXX.host='${CXX}' \
++    CXXFLAGS.host='${CPPFLAGS} ${CXXFLAGS}' \
++    LDFLAGS.host='${LDFLAGS}' \
++    AR.host='${AR}' \
++    \
++    builddir_name=./ \
++"
++
++python do_unpack() {
++    import shutil
++
++    bb.build.exec_func('base_do_unpack', d)
++
++    shutil.rmtree(d.getVar('S') + '/deps/openssl', True)
++    if 'ares' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/cares', True)
++    if 'brotli' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/brotli', True)
++    if 'libuv' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/uv', True)
++    if 'nghttp2' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/nghttp2', True)
++    if 'zlib' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/zlib', True)
++}
++
++# Node is way too cool to use proper autotools, so we install two wrappers to forcefully inject proper arch cflags to workaround gypi
++do_configure () {
++    export LD="${CXX}"
++    GYP_DEFINES="${GYP_DEFINES}" export GYP_DEFINES
++    # $TARGET_ARCH settings don't match --dest-cpu settings
++    python3 configure.py --prefix=${prefix} --cross-compiling --without-snapshot --shared-openssl \
++               --without-dtrace \
++               --without-etw \
++               --dest-cpu="${@map_nodejs_arch(d.getVar('TARGET_ARCH'), d)}" \
++               --dest-os=linux \
++               --libdir=${D}${libdir} \
++               ${ARCHFLAGS} \
++               ${PACKAGECONFIG_CONFARGS}
++}
++
++do_compile () {
++    export LD="${CXX}"
++    oe_runmake BUILDTYPE=Release
++}
++
++do_install () {
++    oe_runmake install DESTDIR=${D}
++
++    # wasn't updated since 2009 and is the only thing requiring python2 in runtime
++    # ERROR: nodejs-12.14.1-r0 do_package_qa: QA Issue: /usr/lib/node_modules/npm/node_modules/node-gyp/gyp/samples/samples contained in package nodejs-npm requires /usr/bin/python, but no providers found in RDEPENDS_nodejs-npm? [file-rdeps]
++    rm -f ${D}${exec_prefix}/lib/node_modules/npm/node_modules/node-gyp/gyp/samples/samples
++}
++
++do_install_append_class-native() {
++    # use node from PATH instead of absolute path to sysroot
++    # node-v0.10.25/tools/install.py is using:
++    # shebang = os.path.join(node_prefix, 'bin/node')
++    # update_shebang(link_path, shebang)
++    # and node_prefix can be very long path to bindir in native sysroot and
++    # when it exceeds 128 character shebang limit it's stripped to incorrect path
++    # and npm fails to execute like in this case with 133 characters show in log.do_install:
++    # updating shebang of /home/jenkins/workspace/build-webos-nightly/device/qemux86/label/open-webos-builder/BUILD-qemux86/work/x86_64-linux/nodejs-native/0.10.15-r0/image/home/jenkins/workspace/build-webos-nightly/device/qemux86/label/open-webos-builder/BUILD-qemux86/sysroots/x86_64-linux/usr/bin/npm to /home/jenkins/workspace/build-webos-nightly/device/qemux86/label/open-webos-builder/BUILD-qemux86/sysroots/x86_64-linux/usr/bin/node
++    # /usr/bin/npm is symlink to /usr/lib/node_modules/npm/bin/npm-cli.js
++    # use sed on npm-cli.js because otherwise symlink is replaced with normal file and
++    # npm-cli.js continues to use old shebang
++    sed "1s^.*^#\!/usr/bin/env node^g" -i ${D}${exec_prefix}/lib/node_modules/npm/bin/npm-cli.js
++
++    # Install the native binaries to provide it within sysroot for the target compilation
++    install -d ${D}${bindir}
++    install -m 0755 ${S}/out/Release/torque ${D}${bindir}/torque
++    install -m 0755 ${S}/out/Release/bytecode_builtins_list_generator ${D}${bindir}/bytecode_builtins_list_generator
++    if ${@bb.utils.contains('PACKAGECONFIG','icu','true','false',d)}; then
++        install -m 0755 ${S}/out/Release/gen-regexp-special-case ${D}${bindir}/gen-regexp-special-case
++    fi
++    install -m 0755 ${S}/out/Release/mkcodecache ${D}${bindir}/mkcodecache
++    install -m 0755 ${S}/out/Release/node_mksnapshot ${D}${bindir}/node_mksnapshot
++}
++
++do_install_append_class-target() {
++    sed "1s^.*^#\!${bindir}/env node^g" -i ${D}${exec_prefix}/lib/node_modules/npm/bin/npm-cli.js
++}
++
++PACKAGES =+ "${PN}-npm"
++FILES_${PN}-npm = "${exec_prefix}/lib/node_modules ${bindir}/npm ${bindir}/npx"
++RDEPENDS_${PN}-npm = "bash python3-core python3-shell python3-datetime \
++    python3-misc python3-multiprocessing"
++
++PACKAGES =+ "${PN}-systemtap"
++FILES_${PN}-systemtap = "${datadir}/systemtap"
++
++BBCLASSEXTEND = "native"
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs_14.18.1.bb b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs_14.18.1.bb
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs_14.18.1.bb	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_12.22.12/nodejs_14.18.1.bb	2024-08-02 09:22:58.239987762 +0200
+@@ -0,0 +1,209 @@
++DESCRIPTION = "nodeJS Evented I/O for V8 JavaScript"
++HOMEPAGE = "http://nodejs.org"
++LICENSE = "MIT & BSD & Artistic-2.0"
++LIC_FILES_CHKSUM = "file://LICENSE;md5=6768abdfc4dae4fde59d6b4df96930f3"
++
++DEFAULT_PREFERENCE = "-1"
++
++DEPENDS = "openssl"
++DEPENDS:append:class-target = " qemu-native"
++DEPENDS:append:class-native = " c-ares-native"
++
++inherit pkgconfig python3native qemu
++
++COMPATIBLE_MACHINE:armv4 = "(!.*armv4).*"
++COMPATIBLE_MACHINE:armv5 = "(!.*armv5).*"
++COMPATIBLE_MACHINE:mips64 = "(!.*mips64).*"
++
++COMPATIBLE_HOST:riscv64 = "null"
++COMPATIBLE_HOST:riscv32 = "null"
++
++SRC_URI = "http://nodejs.org/dist/v${PV}/node-v${PV}.tar.xz \
++           file://0001-Disable-running-gyp-files-for-bundled-deps-nodejs14.patch \
++           file://0003-Install-both-binaries-and-use-libdir-nodejs14.patch \
++           file://0004-v8-don-t-override-ARM-CFLAGS.patch \
++           file://big-endian.patch \
++           file://mips-warnings.patch \
++           file://mips-less-memory-nodejs14.patch \
++           file://0001-jinja-tests.py-add-py-3.10-fix-nodejs14.patch \
++           file://CVE-2022-32212.patch \
++           file://CVE-2022-35255.patch \
++           file://CVE-2022-43548.patch \
++           file://gcc13.patch \
++           "
++SRC_URI:append:class-target = " \
++           file://0002-Using-native-binaries-nodejs14.patch \
++           "
++SRC_URI:append:toolchain-clang:x86 = " \
++           file://libatomic-nodejs14.patch \
++           "
++SRC_URI:append:toolchain-clang:powerpc64le = " \
++           file://0001-ppc64-Do-not-use-mminimal-toc-with-clang-nodejs14.patch \
++           "
++SRC_URI[sha256sum] = "3fa1d71adddfab2f5e3e41874b4eddbdf92b65cade4a43922fb1e437afcf89ed"
++
++S = "${WORKDIR}/node-v${PV}"
++
++# v8 errors out if you have set CCACHE
++CCACHE = ""
++
++def map_nodejs_arch(a, d):
++    import re
++
++    if   re.match('i.86$', a): return 'ia32'
++    elif re.match('x86_64$', a): return 'x64'
++    elif re.match('aarch64$', a): return 'arm64'
++    elif re.match('(powerpc64|powerpc64le|ppc64le)$', a): return 'ppc64'
++    elif re.match('powerpc$', a): return 'ppc'
++    return a
++
++ARCHFLAGS:arm = "${@bb.utils.contains('TUNE_FEATURES', 'callconvention-hard', '--with-arm-float-abi=hard', '--with-arm-float-abi=softfp', d)} \
++                 ${@bb.utils.contains('TUNE_FEATURES', 'neon', '--with-arm-fpu=neon', \
++                    bb.utils.contains('TUNE_FEATURES', 'vfpv3d16', '--with-arm-fpu=vfpv3-d16', \
++                    bb.utils.contains('TUNE_FEATURES', 'vfpv3', '--with-arm-fpu=vfpv3', \
++                    '--with-arm-fpu=vfp', d), d), d)}"
++GYP_DEFINES:append:mipsel = " mips_arch_variant='r1' "
++ARCHFLAGS ?= ""
++
++PACKAGECONFIG ??= "brotli icu zlib"
++
++PACKAGECONFIG[ares] = "--shared-cares,,c-ares"
++PACKAGECONFIG[brotli] = "--shared-brotli,,brotli"
++PACKAGECONFIG[icu] = "--with-intl=system-icu,--without-intl,icu"
++PACKAGECONFIG[libuv] = "--shared-libuv,,libuv"
++PACKAGECONFIG[nghttp2] = "--shared-nghttp2,,nghttp2"
++PACKAGECONFIG[shared] = "--shared"
++PACKAGECONFIG[zlib] = "--shared-zlib,,zlib"
++
++# We don't want to cross-compile during target compile,
++# and we need to use the right flags during host compile,
++# too.
++EXTRA_OEMAKE = "\
++    CC.host='${CC}' \
++    CFLAGS.host='${CPPFLAGS} ${CFLAGS}' \
++    CXX.host='${CXX}' \
++    CXXFLAGS.host='${CPPFLAGS} ${CXXFLAGS}' \
++    LDFLAGS.host='${LDFLAGS}' \
++    AR.host='${AR}' \
++    \
++    builddir_name=./ \
++"
++
++python do_unpack() {
++    import shutil
++
++    bb.build.exec_func('base_do_unpack', d)
++
++    if 'ares' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/cares', True)
++    if 'brotli' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/brotli', True)
++    if 'libuv' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/uv', True)
++    if 'nghttp2' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/nghttp2', True)
++    if 'zlib' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/zlib', True)
++}
++
++# V8's JIT infrastructure requires binaries such as mksnapshot and
++# mkpeephole to be run in the host during the build. However, these
++# binaries must have the same bit-width as the target (e.g. a x86_64
++# host targeting ARMv6 needs to produce a 32-bit binary). Instead of
++# depending on a third Yocto toolchain, we just build those binaries
++# for the target and run them on the host with QEMU.
++python do_create_v8_qemu_wrapper () {
++    """Creates a small wrapper that invokes QEMU to run some target V8 binaries
++    on the host."""
++    qemu_libdirs = [d.expand('${STAGING_DIR_HOST}${libdir}'),
++                    d.expand('${STAGING_DIR_HOST}${base_libdir}')]
++    qemu_cmd = qemu_wrapper_cmdline(d, d.getVar('STAGING_DIR_HOST', True),
++                                    qemu_libdirs)
++    wrapper_path = d.expand('${B}/v8-qemu-wrapper.sh')
++    with open(wrapper_path, 'w') as wrapper_file:
++        wrapper_file.write("""#!/bin/sh
++
++# This file has been generated automatically.
++# It invokes QEMU to run binaries built for the target in the host during the
++# build process.
++
++%s "$@"
++""" % qemu_cmd)
++    os.chmod(wrapper_path, 0o755)
++}
++
++do_create_v8_qemu_wrapper[dirs] = "${B}"
++addtask create_v8_qemu_wrapper after do_configure before do_compile
++
++# Work around compatibility issues with gcc-13 on host
++BUILD_CXXFLAGS += "-fpermissive"
++
++LDFLAGS:append:x86 = " -latomic"
++
++# Node is way too cool to use proper autotools, so we install two wrappers to forcefully inject proper arch cflags to workaround gypi
++do_configure () {
++    export LD="${CXX}"
++    GYP_DEFINES="${GYP_DEFINES}" export GYP_DEFINES
++    # $TARGET_ARCH settings don't match --dest-cpu settings
++    python3 configure.py --prefix=${prefix} --cross-compiling \
++               --without-dtrace \
++               --without-etw \
++               --dest-cpu="${@map_nodejs_arch(d.getVar('TARGET_ARCH'), d)}" \
++               --dest-os=linux \
++               --libdir=${D}${libdir} \
++               ${ARCHFLAGS} \
++               ${PACKAGECONFIG_CONFARGS}
++}
++
++do_compile () {
++    export LD="${CXX}"
++    install -Dm 0755 ${B}/v8-qemu-wrapper.sh ${B}/out/Release/v8-qemu-wrapper.sh
++    oe_runmake BUILDTYPE=Release
++}
++
++do_install () {
++    oe_runmake install DESTDIR=${D}
++
++    # wasn't updated since 2009 and is the only thing requiring python2 in runtime
++    # ERROR: nodejs-12.14.1-r0 do_package_qa: QA Issue: /usr/lib/node_modules/npm/node_modules/node-gyp/gyp/samples/samples contained in package nodejs-npm requires /usr/bin/python, but no providers found in RDEPENDS:nodejs-npm? [file-rdeps]
++    rm -f ${D}${exec_prefix}/lib/node_modules/npm/node_modules/node-gyp/gyp/samples/samples
++}
++
++do_install:append:class-native() {
++    # use node from PATH instead of absolute path to sysroot
++    # node-v0.10.25/tools/install.py is using:
++    # shebang = os.path.join(node_prefix, 'bin/node')
++    # update_shebang(link_path, shebang)
++    # and node_prefix can be very long path to bindir in native sysroot and
++    # when it exceeds 128 character shebang limit it's stripped to incorrect path
++    # and npm fails to execute like in this case with 133 characters show in log.do_install:
++    # updating shebang of /home/jenkins/workspace/build-webos-nightly/device/qemux86/label/open-webos-builder/BUILD-qemux86/work/x86_64-linux/nodejs-native/0.10.15-r0/image/home/jenkins/workspace/build-webos-nightly/device/qemux86/label/open-webos-builder/BUILD-qemux86/sysroots/x86_64-linux/usr/bin/npm to /home/jenkins/workspace/build-webos-nightly/device/qemux86/label/open-webos-builder/BUILD-qemux86/sysroots/x86_64-linux/usr/bin/node
++    # /usr/bin/npm is symlink to /usr/lib/node_modules/npm/bin/npm-cli.js
++    # use sed on npm-cli.js because otherwise symlink is replaced with normal file and
++    # npm-cli.js continues to use old shebang
++    sed "1s^.*^#\!/usr/bin/env node^g" -i ${D}${exec_prefix}/lib/node_modules/npm/bin/npm-cli.js
++
++    # Install the native binaries to provide it within sysroot for the target compilation
++    install -d ${D}${bindir}
++    install -m 0755 ${S}/out/Release/torque ${D}${bindir}/torque
++    install -m 0755 ${S}/out/Release/bytecode_builtins_list_generator ${D}${bindir}/bytecode_builtins_list_generator
++    if ${@bb.utils.contains('PACKAGECONFIG','icu','true','false',d)}; then
++        install -m 0755 ${S}/out/Release/gen-regexp-special-case ${D}${bindir}/gen-regexp-special-case
++    fi
++    install -m 0755 ${S}/out/Release/mkcodecache ${D}${bindir}/mkcodecache
++    install -m 0755 ${S}/out/Release/node_mksnapshot ${D}${bindir}/node_mksnapshot
++}
++
++do_install:append:class-target() {
++    sed "1s^.*^#\!${bindir}/env node^g" -i ${D}${exec_prefix}/lib/node_modules/npm/bin/npm-cli.js
++}
++
++PACKAGES =+ "${PN}-npm"
++FILES:${PN}-npm = "${exec_prefix}/lib/node_modules ${bindir}/npm ${bindir}/npx"
++RDEPENDS:${PN}-npm = "bash python3-core python3-shell python3-datetime \
++    python3-misc python3-multiprocessing"
++
++PACKAGES =+ "${PN}-systemtap"
++FILES:${PN}-systemtap = "${datadir}/systemtap"
++
++BBCLASSEXTEND = "native"
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-Disable-running-gyp-files-for-bundled-deps.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-Disable-running-gyp-files-for-bundled-deps.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-Disable-running-gyp-files-for-bundled-deps.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-Disable-running-gyp-files-for-bundled-deps.patch	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,46 @@
++From 7d94bfe53beeb2d25eb5f2ff6b1d509df7e6ab80 Mon Sep 17 00:00:00 2001
++From: Zuzana Svetlikova <zsvetlik@redhat.com>
++Date: Thu, 27 Apr 2017 14:25:42 +0200
++Subject: [PATCH] Disable running gyp on shared deps
++
++Upstream-Status: Inappropriate [embedded specific]
++
++Probably imported from:
++https://src.fedoraproject.org/rpms/nodejs/c/41af04f2a3c050fb44628e91ac65fd225b927acb?branch=22609d8c1bfeaa21fe0057645af20b3a2ccc7f53
++which is probably based on dont-run-gyp-files-for-bundled-deps.patch added in:
++https://github.com/alpinelinux/aports/commit/6662eb3199902e8451fb20dce82554ad96f796bb
++
++We also explicitly prune some dependencies from source in the bitbake recipe:
++
++python prune_sources() {
++    import shutil
++
++    shutil.rmtree(d.getVar('S') + '/deps/openssl')
++    if 'ares' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/cares')
++    if 'brotli' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/brotli')
++    if 'libuv' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/uv')
++    if 'nghttp2' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/nghttp2')
++    if 'zlib' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/zlib')
++}
++do_unpack[postfuncs] += "prune_sources"
++
++---
++ Makefile | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++--- a/Makefile
+++++ b/Makefile
++@@ -169,7 +169,7 @@ with-code-cache test-code-cache:
++ 	$(warning '$@' target is a noop)
++ 
++ out/Makefile: config.gypi common.gypi node.gyp \
++-	deps/uv/uv.gyp deps/llhttp/llhttp.gyp deps/zlib/zlib.gyp \
+++	deps/llhttp/llhttp.gyp \
++ 	deps/simdutf/simdutf.gyp deps/ada/ada.gyp \
++ 	tools/v8_gypfiles/toolchain.gypi tools/v8_gypfiles/features.gypi \
++ 	tools/v8_gypfiles/inspector.gypi tools/v8_gypfiles/v8.gyp
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-liftoff-Correct-function-signatures.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-liftoff-Correct-function-signatures.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-liftoff-Correct-function-signatures.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-liftoff-Correct-function-signatures.patch	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,85 @@
++From dc3652c0abcdf8573fd044907b19d8eda7ca1124 Mon Sep 17 00:00:00 2001
++From: Khem Raj <raj.khem@gmail.com>
++Date: Wed, 20 Oct 2021 12:49:58 -0700
++Subject: [PATCH] [liftoff] Correct function signatures
++
++Fixes builds on mips where clang reports an error
++../deps/v8/src/wasm/baseline/mips/liftoff-assembler-mips.h:661:5: error: no matching member function for call to 'Move'
++    Move(tmp, src, type.value_type());
++    ^~~~
++
++Upstream-Status: Submitted [https://chromium-review.googlesource.com/c/v8/v8/+/3235674]
++
++Signed-off-by: Archana Polampalli <archana.polampalli@windriver.com>
++---
++ deps/v8/src/wasm/baseline/liftoff-assembler.h               | 6 +++---
++ deps/v8/src/wasm/baseline/mips/liftoff-assembler-mips.h     | 2 +-
++ deps/v8/src/wasm/baseline/mips64/liftoff-assembler-mips64.h | 2 +-
++ .../src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h   | 2 +-
++ 4 files changed, 6 insertions(+), 6 deletions(-)
++
++diff --git a/deps/v8/src/wasm/baseline/liftoff-assembler.h b/deps/v8/src/wasm/baseline/liftoff-assembler.h
++index 22c7f73a..db4cb168 100644
++--- a/deps/v8/src/wasm/baseline/liftoff-assembler.h
+++++ b/deps/v8/src/wasm/baseline/liftoff-assembler.h
++@@ -646,7 +646,7 @@ class LiftoffAssembler : public TurboAssembler {
++   void FinishCall(const ValueKindSig*, compiler::CallDescriptor*);
++ 
++   // Move {src} into {dst}. {src} and {dst} must be different.
++-  void Move(LiftoffRegister dst, LiftoffRegister src, ValueKind);
+++  void Move(LiftoffRegister dst, LiftoffRegister src, ValueKind kind);
++ 
++   // Parallel register move: For a list of tuples <dst, src, kind>, move the
++   // {src} register of kind {kind} into {dst}. If {src} equals {dst}, ignore
++@@ -795,8 +795,8 @@ class LiftoffAssembler : public TurboAssembler {
++   inline void MoveStackValue(uint32_t dst_offset, uint32_t src_offset,
++                              ValueKind);
++ 
++-  inline void Move(Register dst, Register src, ValueKind);
++-  inline void Move(DoubleRegister dst, DoubleRegister src, ValueKind);
+++  inline void Move(Register dst, Register src, ValueKind kind);
+++  inline void Move(DoubleRegister dst, DoubleRegister src, ValueKind kind);
++ 
++   inline void Spill(int offset, LiftoffRegister, ValueKind);
++   inline void Spill(int offset, WasmValue);
++diff --git a/deps/v8/src/wasm/baseline/mips/liftoff-assembler-mips.h b/deps/v8/src/wasm/baseline/mips/liftoff-assembler-mips.h
++index c76fd2f4..0fffe231 100644
++--- a/deps/v8/src/wasm/baseline/mips/liftoff-assembler-mips.h
+++++ b/deps/v8/src/wasm/baseline/mips/liftoff-assembler-mips.h
++@@ -661,7 +661,7 @@ void LiftoffAssembler::Store(Register dst_addr, Register offset_reg,
++     pinned = pinned | LiftoffRegList{dst_op.rm(), src};
++     LiftoffRegister tmp = GetUnusedRegister(src.reg_class(), pinned);
++     // Save original value.
++-    Move(tmp, src, type.value_type());
+++    Move(tmp, src, type.value_type().kind());
++ 
++     src = tmp;
++     pinned.set(tmp);
++diff --git a/deps/v8/src/wasm/baseline/mips64/liftoff-assembler-mips64.h b/deps/v8/src/wasm/baseline/mips64/liftoff-assembler-mips64.h
++index 36413545..48207337 100644
++--- a/deps/v8/src/wasm/baseline/mips64/liftoff-assembler-mips64.h
+++++ b/deps/v8/src/wasm/baseline/mips64/liftoff-assembler-mips64.h
++@@ -593,7 +593,7 @@ void LiftoffAssembler::Store(Register dst_addr, Register offset_reg,
++     pinned.set(dst_op.rm());
++     LiftoffRegister tmp = GetUnusedRegister(src.reg_class(), pinned);
++     // Save original value.
++-    Move(tmp, src, type.value_type());
+++    Move(tmp, src, type.value_type().kind());
++ 
++     src = tmp;
++     pinned.set(tmp);
++diff --git a/deps/v8/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h b/deps/v8/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
++index 642a7d2a..56ffcc2a 100644
++--- a/deps/v8/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
+++++ b/deps/v8/src/wasm/baseline/riscv64/liftoff-assembler-riscv64.h
++@@ -589,7 +589,7 @@ void LiftoffAssembler::Store(Register dst_addr, Register offset_reg,
++     pinned.set(dst_op.rm());
++     LiftoffRegister tmp = GetUnusedRegister(src.reg_class(), pinned);
++     // Save original value.
++-    Move(tmp, src, type.value_type());
+++    Move(tmp, src, type.value_type().kind());
++ 
++     src = tmp;
++     pinned.set(tmp);
++--
++2.34.1
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-mips-Use-32bit-cast-for-operand-on-mips32.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-mips-Use-32bit-cast-for-operand-on-mips32.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-mips-Use-32bit-cast-for-operand-on-mips32.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-mips-Use-32bit-cast-for-operand-on-mips32.patch	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,34 @@
++From e65dde8db17da5acddeef7eb9316199c4e5e0811 Mon Sep 17 00:00:00 2001
++From: Khem Raj <raj.khem@gmail.com>
++Date: Tue, 19 Apr 2022 12:40:25 -0700
++Subject: [PATCH] mips: Use 32bit cast for operand on mips32
++
++Fixes
++deps/v8/src/compiler/backend/mips/code-generator-mips.cc: In member function 'void v8::internal::compiler::CodeGenerator::AssembleReturn(v8::internal::compiler::InstructionOperand*)':
++../deps/v8/src/compiler/backend/mips/code-generator-mips.cc:4233:48: error: call of overloaded 'Operand(int64_t)' is ambiguous
++ 4233 |                 Operand(static_cast<int64_t>(0)));
++      |                                                ^
++
++Upstream-Status: Pending
++
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++---
++ deps/v8/src/compiler/backend/mips/code-generator-mips.cc | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/deps/v8/src/compiler/backend/mips/code-generator-mips.cc b/deps/v8/src/compiler/backend/mips/code-generator-mips.cc
++index 2b8197e..b226140 100644
++--- a/deps/v8/src/compiler/backend/mips/code-generator-mips.cc
+++++ b/deps/v8/src/compiler/backend/mips/code-generator-mips.cc
++@@ -4230,7 +4230,7 @@ void CodeGenerator::AssembleReturn(InstructionOperand* additional_pop_count) {
++     } else if (FLAG_debug_code) {
++       __ Assert(eq, AbortReason::kUnexpectedAdditionalPopValue,
++                 g.ToRegister(additional_pop_count),
++-                Operand(static_cast<int64_t>(0)));
+++                Operand(static_cast<int32_t>(0)));
++     }
++   }
++   // Functions with JS linkage have at least one parameter (the receiver).
++-- 
++2.36.0
++
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-ppc64-Do-not-use-mminimal-toc-with-clang.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-ppc64-Do-not-use-mminimal-toc-with-clang.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-ppc64-Do-not-use-mminimal-toc-with-clang.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-ppc64-Do-not-use-mminimal-toc-with-clang.patch	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,25 @@
++From 0976af0f3b328436ea44a74a406f311adb2ab211 Mon Sep 17 00:00:00 2001
++From: Khem Raj <raj.khem@gmail.com>
++Date: Tue, 15 Jun 2021 19:01:31 -0700
++Subject: [PATCH] ppc64: Do not use -mminimal-toc with clang
++
++clang does not support this option
++
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++---
++Upstream-Status: Pending
++
++ common.gypi | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++--- a/common.gypi
+++++ b/common.gypi
++@@ -417,7 +417,7 @@
++             'ldflags': [ '-m32' ],
++           }],
++           [ 'target_arch=="ppc64" and OS!="aix"', {
++-            'cflags': [ '-m64', '-mminimal-toc' ],
+++            'cflags': [ '-m64' ],
++             'ldflags': [ '-m64' ],
++           }],
++           [ 'target_arch=="s390x"', {
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-Using-native-binaries.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-Using-native-binaries.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-Using-native-binaries.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0001-Using-native-binaries.patch	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,77 @@
++From 6c3ac20477a4bac643088f24df3c042e627fafa9 Mon Sep 17 00:00:00 2001
++From: Guillaume Burel <guillaume.burel@stormshield.eu>
++Date: Fri, 3 Jan 2020 11:25:54 +0100
++Subject: [PATCH] Using native binaries
++
++Upstream-Status: Inappropriate [embedded specific]
++
++Originally added in:
++https://git.openembedded.org/meta-openembedded/commit/?id=1c8e4a679ae382f953b2e5c7a4966a4646314f3e
++later extended and renamed in:
++https://git.openembedded.org/meta-openembedded/commit/?id=feeb172d1a8bf010490d22b8df9448b20d9d2aed
++
++Signed-off-by: Archana Polampalli <archana.polampalli@windriver.com>
++---
++ node.gyp                 | 1 +
++ tools/v8_gypfiles/v8.gyp | 5 +++++
++ 2 files changed, 6 insertions(+)
++
++diff --git a/node.gyp b/node.gyp
++index e8e1d9f9..e60ccc10 100644
++--- a/node.gyp
+++++ b/node.gyp
++@@ -320,6 +320,7 @@
++                   'action_name': 'node_mksnapshot',
++                   'process_outputs_as_sources': 1,
++                   'inputs': [
+++                    '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
++                     '<(node_mksnapshot_exec)',
++                     '<(node_snapshot_main)',
++                   ],
++diff --git a/tools/v8_gypfiles/v8.gyp b/tools/v8_gypfiles/v8.gyp
++index 42e26cd9..bc721991 100644
++--- a/tools/v8_gypfiles/v8.gyp
+++++ b/tools/v8_gypfiles/v8.gyp
++@@ -68,6 +68,7 @@
++         {
++           'action_name': 'run_torque_action',
++           'inputs': [  # Order matters.
+++            '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
++             '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)torque<(EXECUTABLE_SUFFIX)',
++             '<@(torque_files)',
++           ],
++@@ -99,6 +100,7 @@
++             '<@(torque_outputs_inc)',
++           ],
++           'action': [
+++            '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
++             '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)torque<(EXECUTABLE_SUFFIX)',
++             '-o', '<(SHARED_INTERMEDIATE_DIR)/torque-generated',
++             '-v8-root', '<(V8_ROOT)',
++@@ -211,6 +213,7 @@
++         {
++           'action_name': 'generate_bytecode_builtins_list_action',
++           'inputs': [
+++            '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
++             '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)bytecode_builtins_list_generator<(EXECUTABLE_SUFFIX)',
++           ],
++           'outputs': [
++@@ -400,6 +403,7 @@
++             ],
++           },
++           'inputs': [
+++            '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
++             '<(mksnapshot_exec)',
++           ],
++           'outputs': [
++@@ -1539,6 +1543,7 @@
++         {
++           'action_name': 'run_gen-regexp-special-case_action',
++           'inputs': [
+++            '<(PRODUCT_DIR)/v8-qemu-wrapper.sh',
++             '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)gen-regexp-special-case<(EXECUTABLE_SUFFIX)',
++           ],
++           'outputs': [
++-- 
++2.34.1
++
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0004-v8-don-t-override-ARM-CFLAGS.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0004-v8-don-t-override-ARM-CFLAGS.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0004-v8-don-t-override-ARM-CFLAGS.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/0004-v8-don-t-override-ARM-CFLAGS.patch	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,102 @@
++From 47ee5cc5501289205d3e8e9f27ea9daf18cebac1 Mon Sep 17 00:00:00 2001
++From: =?UTF-8?q?Andr=C3=A9=20Draszik?= <git@andred.net>
++Date: Sat, 9 Nov 2019 14:45:30 +0000
++Subject: [PATCH] v8: don't override ARM CFLAGS
++MIME-Version: 1.0
++Content-Type: text/plain; charset=UTF-8
++Content-Transfer-Encoding: 8bit
++
++This overrides yocto-provided build flags with its own, e.g we get
++    arm-poky-linux-musleabi-g++  -mthumb -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a7 \
++                                 ... \
++                                  -march=armv7-a -mfpu=neon -mfloat-abi=hard -marm
++
++Causing the latter to override the former, and compiler warnings:
++    cc1plus: warning: switch '-mcpu=cortex-a7' conflicts with '-march=armv7-a' switch
++
++Patch this out, so that yocto-provided flags take precedence.
++Note that in reality the same should probably be done for all the other
++supported architectures, too.
++
++Note that this also switches to Thumb(2) mode (in my case). No obvious
++problems have been noted during compilation or runtime.
++
++Upstream-Status: Inappropriate [oe-specific]
++Signed-off-by: André Draszik <git@andred.net>
++---
++ tools/v8_gypfiles/toolchain.gypi | 52 ++------------------------------
++ 1 file changed, 2 insertions(+), 50 deletions(-)
++
++diff --git a/tools/v8_gypfiles/toolchain.gypi b/tools/v8_gypfiles/toolchain.gypi
++index 264b3e478e..0b41848145 100644
++--- a/tools/v8_gypfiles/toolchain.gypi
+++++ b/tools/v8_gypfiles/toolchain.gypi
++@@ -211,31 +211,7 @@
++         'target_conditions': [
++           ['_toolset=="host"', {
++             'conditions': [
++-              ['v8_target_arch==host_arch', {
++-                # Host built with an Arm CXX compiler.
++-                'conditions': [
++-                  [ 'arm_version==7', {
++-                    'cflags': ['-march=armv7-a',],
++-                  }],
++-                  [ 'arm_version==7 or arm_version=="default"', {
++-                    'conditions': [
++-                      [ 'arm_fpu!="default"', {
++-                        'cflags': ['-mfpu=<(arm_fpu)',],
++-                      }],
++-                    ],
++-                  }],
++-                  [ 'arm_float_abi!="default"', {
++-                    'cflags': ['-mfloat-abi=<(arm_float_abi)',],
++-                  }],
++-                  [ 'arm_thumb==1', {
++-                    'cflags': ['-mthumb',],
++-                  }],
++-                  [ 'arm_thumb==0', {
++-                    'cflags': ['-marm',],
++-                  }],
++-                ],
++-              }, {
++-                # 'v8_target_arch!=host_arch'
+++              ['v8_target_arch!=host_arch', {
++                 # Host not built with an Arm CXX compiler (simulator build).
++                 'conditions': [
++                   [ 'arm_float_abi=="hard"', {
++@@ -254,31 +230,7 @@
++           }],  # _toolset=="host"
++           ['_toolset=="target"', {
++             'conditions': [
++-              ['v8_target_arch==target_arch', {
++-                # Target built with an Arm CXX compiler.
++-                'conditions': [
++-                  [ 'arm_version==7', {
++-                    'cflags': ['-march=armv7-a',],
++-                  }],
++-                  [ 'arm_version==7 or arm_version=="default"', {
++-                    'conditions': [
++-                      [ 'arm_fpu!="default"', {
++-                        'cflags': ['-mfpu=<(arm_fpu)',],
++-                      }],
++-                    ],
++-                  }],
++-                  [ 'arm_float_abi!="default"', {
++-                    'cflags': ['-mfloat-abi=<(arm_float_abi)',],
++-                  }],
++-                  [ 'arm_thumb==1', {
++-                    'cflags': ['-mthumb',],
++-                  }],
++-                  [ 'arm_thumb==0', {
++-                    'cflags': ['-marm',],
++-                  }],
++-                ],
++-              }, {
++-                # 'v8_target_arch!=target_arch'
+++              ['v8_target_arch!=target_arch', {
++                 # Target not built with an Arm CXX compiler (simulator build).
++                 'conditions': [
++                   [ 'arm_float_abi=="hard"', {
++-- 
++2.20.1
++
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/big-endian.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/big-endian.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/big-endian.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/big-endian.patch	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,18 @@
++
++https://github.com/v8/v8/commit/878ccb33bd3cf0e6dc018ff8d15843f585ac07be
++
++did some automated cleanups but it missed big-endian code.
++
++Upstream-Status: Pending
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++--- a/deps/v8/src/runtime/runtime-utils.h
+++++ b/deps/v8/src/runtime/runtime-utils.h
++@@ -126,7 +126,7 @@ static inline ObjectPair MakePair(Object
++ #if defined(V8_TARGET_LITTLE_ENDIAN)
++   return x.ptr() | (static_cast<ObjectPair>(y.ptr()) << 32);
++ #elif defined(V8_TARGET_BIG_ENDIAN)
++-  return y->ptr() | (static_cast<ObjectPair>(x->ptr()) << 32);
+++  return y.ptr() | (static_cast<ObjectPair>(x.ptr()) << 32);
++ #else
++ #error Unknown endianness
++ #endif
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/libatomic.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/libatomic.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/libatomic.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/libatomic.patch	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,21 @@
++Link mksnapshot with libatomic on x86
++
++Clang-12 on x86 emits atomic builtins
++
++Fixes
++| module-compiler.cc:(.text._ZN2v88internal4wasm12_GLOBAL__N_123ExecuteCompilationUnitsERKSt10shared_ptrINS2_22BackgroundCompileTokenEEPNS0_8CountersEiNS2_19CompileBaselineOnlyE+0x558): un
++defined reference to `__atomic_load'
++
++Upstream-Status: Pending
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++
++--- a/tools/v8_gypfiles/v8.gyp
+++++ b/tools/v8_gypfiles/v8.gyp
++@@ -1436,6 +1436,7 @@
++     {
++       'target_name': 'mksnapshot',
++       'type': 'executable',
+++      'libraries': [ '-latomic' ],
++       'dependencies': [
++         'v8_base_without_compiler',
++         'v8_compiler_for_mksnapshot',
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/mips-less-memory.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/mips-less-memory.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/mips-less-memory.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/mips-less-memory.patch	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,37 @@
++Description: mksnapshot uses too much memory on 32-bit mipsel
++Author: Jérémy Lal <kapouer@melix.org>
++Last-Update: 2020-06-03
++Forwarded: https://bugs.chromium.org/p/v8/issues/detail?id=10586
++
++This ensures that we reserve 500M instead of 2G range for codegen
++ensures that qemu-mips can allocate such large ranges
++
++Upstream-Status: Inappropriate [embedded specific]
++
++Imported from debian https://salsa.debian.org/js-team/nodejs/-/blob/master-12.x/debian/patches/mips-less-memory.patch
++https://buildd.debian.org/status/fetch.php?pkg=nodejs&arch=mipsel&ver=12.17.0~dfsg-2&stamp=1591050388&raw=0
++
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++
++--- a/deps/v8/src/common/globals.h
+++++ b/deps/v8/src/common/globals.h
++@@ -224,7 +224,7 @@ constexpr size_t kMinimumCodeRangeSize =
++ constexpr size_t kMinExpectedOSPageSize = 64 * KB;  // OS page on PPC Linux
++ #elif V8_TARGET_ARCH_MIPS
++ constexpr bool kPlatformRequiresCodeRange = false;
++-constexpr size_t kMaximalCodeRangeSize = 2048LL * MB;
+++constexpr size_t kMaximalCodeRangeSize = 512 * MB;
++ constexpr size_t kMinimumCodeRangeSize = 0 * MB;
++ constexpr size_t kMinExpectedOSPageSize = 4 * KB;  // OS page.
++ #else
++--- a/deps/v8/src/codegen/mips/constants-mips.h
+++++ b/deps/v8/src/codegen/mips/constants-mips.h
++@@ -140,7 +140,7 @@ const uint32_t kLeastSignificantByteInIn
++ namespace v8 {
++ namespace internal {
++ 
++-constexpr size_t kMaxPCRelativeCodeRangeInMB = 4096;
+++constexpr size_t kMaxPCRelativeCodeRangeInMB = 1024;
++ 
++ // -----------------------------------------------------------------------------
++ // Registers and FPURegisters.
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/run-ptest b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/run-ptest
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/run-ptest	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/run-ptest	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,3 @@
++#!/bin/sh
++
++./cctest
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/system-c-ares.patch b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/system-c-ares.patch
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/system-c-ares.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs/system-c-ares.patch	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,24 @@
++keep nodejs compatible with c-ares 1.17.1
++
++Upstream-Status: Inappropriate [c-ares specific]
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++
++--- a/src/cares_wrap.h
+++++ b/src/cares_wrap.h
++@@ -22,7 +22,15 @@
++ # include <netdb.h>
++ #endif  // __POSIX__
++ 
++-# include <ares_nameser.h>
+++#if defined(__ANDROID__) || \
+++    defined(__MINGW32__) || \
+++    defined(__OpenBSD__) || \
+++    defined(_MSC_VER)
+++
+++# include <nameser.h>
+++#else
+++# include <arpa/nameser.h>
+++#endif
++ 
++ namespace node {
++ namespace cares_wrap {
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs_18.17.1.bb b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs_18.17.1.bb
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs_18.17.1.bb	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs_18.17.1.bb	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,185 @@
++DESCRIPTION = "nodeJS Evented I/O for V8 JavaScript"
++HOMEPAGE = "http://nodejs.org"
++LICENSE = "MIT & ISC & BSD-2-Clause & BSD-3-Clause & Artistic-2.0 & Apache-2.0"
++LIC_FILES_CHKSUM = "file://LICENSE;md5=bc1f9ebe76be76f163e3b675303ad9cd"
++
++CVE_PRODUCT = "nodejs node.js"
++
++DEPENDS = "openssl file-replacement-native"
++DEPENDS_append_class-target = " qemu-native"
++DEPENDS_append_class-native = " c-ares-native"
++
++inherit pkgconfig python3native qemu ptest
++
++COMPATIBLE_MACHINE_armv4 = "(!.*armv4).*"
++COMPATIBLE_MACHINE_armv5 = "(!.*armv5).*"
++COMPATIBLE_MACHINE_mips64 = "(!.*mips64).*"
++
++COMPATIBLE_HOST_riscv64 = "null"
++COMPATIBLE_HOST_riscv32 = "null"
++COMPATIBLE_HOST_powerpc = "null"
++
++SRC_URI = "http://nodejs.org/dist/v${PV}/node-v${PV}.tar.xz \
++           file://0001-Disable-running-gyp-files-for-bundled-deps.patch \
++           file://0004-v8-don-t-override-ARM-CFLAGS.patch \
++           file://big-endian.patch \
++           file://mips-less-memory.patch \
++           file://system-c-ares.patch \
++           file://0001-liftoff-Correct-function-signatures.patch \
++           file://0001-mips-Use-32bit-cast-for-operand-on-mips32.patch \
++           file://run-ptest \
++           "
++
++SRC_URI_append_class-target = " \
++           file://0001-Using-native-binaries.patch \
++           "
++SRC_URI_append_toolchain-clang_x86 = " \
++           file://libatomic.patch \
++           "
++SRC_URI_append_toolchain-clang_powerpc64le = " \
++           file://0001-ppc64-Do-not-use-mminimal-toc-with-clang.patch \
++           "
++SRC_URI[sha256sum] = "f215cf03d0f00f07ac0b674c6819f804c1542e16f152da04980022aeccf5e65a"
++
++S = "${WORKDIR}/node-v${PV}"
++
++# v8 errors out if you have set CCACHE
++CCACHE = ""
++
++def map_nodejs_arch(a, d):
++    import re
++
++    if   re.match('i.86$', a): return 'ia32'
++    elif re.match('x86_64$', a): return 'x64'
++    elif re.match('aarch64$', a): return 'arm64'
++    elif re.match('(powerpc64|powerpc64le|ppc64le)$', a): return 'ppc64'
++    elif re.match('powerpc$', a): return 'ppc'
++    return a
++
++ARCHFLAGS_arm = "${@bb.utils.contains('TUNE_FEATURES', 'callconvention-hard', '--with-arm-float-abi=hard', '--with-arm-float-abi=softfp', d)} \
++                 ${@bb.utils.contains('TUNE_FEATURES', 'neon', '--with-arm-fpu=neon', \
++                    bb.utils.contains('TUNE_FEATURES', 'vfpv3d16', '--with-arm-fpu=vfpv3-d16', \
++                    bb.utils.contains('TUNE_FEATURES', 'vfpv3', '--with-arm-fpu=vfpv3', \
++                    '--with-arm-fpu=vfp', d), d), d)}"
++ARCHFLAGS_append_mips = " --v8-lite-mode"
++ARCHFLAGS_append_mipsel = " --v8-lite-mode"
++ARCHFLAGS ?= ""
++
++PACKAGECONFIG ??= "ares brotli icu zlib"
++
++PACKAGECONFIG[ares] = "--shared-cares,,c-ares"
++PACKAGECONFIG[brotli] = "--shared-brotli,,brotli"
++PACKAGECONFIG[icu] = "--with-intl=system-icu,--without-intl,icu"
++PACKAGECONFIG[libuv] = "--shared-libuv,,libuv"
++PACKAGECONFIG[nghttp2] = "--shared-nghttp2,,nghttp2"
++PACKAGECONFIG[shared] = "--shared"
++PACKAGECONFIG[zlib] = "--shared-zlib,,zlib"
++
++# We don't want to cross-compile during target compile,
++# and we need to use the right flags during host compile,
++# too.
++EXTRA_OEMAKE = "\
++    CC.host='${CC} -pie -fPIE' \
++    CFLAGS.host='${CPPFLAGS} ${CFLAGS}' \
++    CXX.host='${CXX} -pie -fPIE' \
++    CXXFLAGS.host='${CPPFLAGS} ${CXXFLAGS}' \
++    LDFLAGS.host='${LDFLAGS}' \
++    AR.host='${AR}' \
++    \
++    builddir_name=./ \
++"
++
++EXTRANATIVEPATH += "file-native"
++
++python prune_sources() {
++    import shutil
++
++    shutil.rmtree(d.getVar('S') + '/deps/openssl')
++    if 'ares' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/cares')
++    if 'brotli' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/brotli')
++    if 'libuv' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/uv')
++    if 'nghttp2' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/nghttp2')
++    if 'zlib' in d.getVar('PACKAGECONFIG'):
++        shutil.rmtree(d.getVar('S') + '/deps/zlib')
++}
++do_unpack[postfuncs] += "prune_sources"
++
++# V8's JIT infrastructure requires binaries such as mksnapshot and
++# mkpeephole to be run in the host during the build. However, these
++# binaries must have the same bit-width as the target (e.g. a x86_64
++# host targeting ARMv6 needs to produce a 32-bit binary). Instead of
++# depending on a third Yocto toolchain, we just build those binaries
++# for the target and run them on the host with QEMU.
++python do_create_v8_qemu_wrapper () {
++    """Creates a small wrapper that invokes QEMU to run some target V8 binaries
++    on the host."""
++    qemu_libdirs = [d.expand('${STAGING_DIR_HOST}${libdir}'),
++                    d.expand('${STAGING_DIR_HOST}${base_libdir}')]
++    qemu_cmd = qemu_wrapper_cmdline(d, d.getVar('STAGING_DIR_HOST'),
++                                    qemu_libdirs)
++    wrapper_path = d.expand('${B}/v8-qemu-wrapper.sh')
++    with open(wrapper_path, 'w') as wrapper_file:
++        wrapper_file.write("""#!/bin/sh
++
++# This file has been generated automatically.
++# It invokes QEMU to run binaries built for the target in the host during the
++# build process.
++
++%s "$@"
++""" % qemu_cmd)
++    os.chmod(wrapper_path, 0o755)
++}
++
++do_create_v8_qemu_wrapper[dirs] = "${B}"
++addtask create_v8_qemu_wrapper after do_configure before do_compile
++
++LDFLAGS_append_x86 = " -latomic"
++
++CROSS_FLAGS = "--cross-compiling"
++CROSS_FLAGS_class-native = "--no-cross-compiling"
++
++# Node is way too cool to use proper autotools, so we install two wrappers to forcefully inject proper arch cflags to workaround gypi
++do_configure () {
++    GYP_DEFINES="${GYP_DEFINES}" export GYP_DEFINES
++    # $TARGET_ARCH settings don't match --dest-cpu settings
++    python3 configure.py --verbose --prefix=${prefix} \
++               --shared-openssl \
++               --without-dtrace \
++               --without-etw \
++               --dest-cpu="${@map_nodejs_arch(d.getVar('TARGET_ARCH'), d)}" \
++               --dest-os=linux \
++               --libdir=${baselib} \
++               ${CROSS_FLAGS} \
++               ${ARCHFLAGS} \
++               ${PACKAGECONFIG_CONFARGS}
++}
++
++do_compile () {
++    install -D ${RECIPE_SYSROOT_NATIVE}/etc/ssl/openssl.cnf ${B}/deps/openssl/nodejs-openssl.cnf
++    install -D ${B}/v8-qemu-wrapper.sh ${B}/out/Release/v8-qemu-wrapper.sh
++    oe_runmake BUILDTYPE=Release
++}
++
++do_install () {
++    oe_runmake install DESTDIR=${D}
++}
++
++do_install_ptest () {
++    cp -r  ${B}/out/Release/cctest ${D}${PTEST_PATH}/
++    cp -r ${B}/test ${D}${PTEST_PATH}
++    chown -R root:root ${D}${PTEST_PATH}
++}
++
++PACKAGES =+ "${PN}-npm"
++FILES_${PN}-npm = "${nonarch_libdir}/node_modules ${bindir}/npm ${bindir}/npx ${bindir}/corepack"
++RDEPENDS_${PN}-npm = "bash python3-core python3-shell python3-datetime \
++    python3-misc python3-multiprocessing"
++
++PACKAGES =+ "${PN}-systemtap"
++FILES_${PN}-systemtap = "${datadir}/systemtap"
++
++BBCLASSEXTEND = "native"
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs-oe-cache-18.17/oe-npm-cache b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs-oe-cache-18.17/oe-npm-cache
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs-oe-cache-18.17/oe-npm-cache	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs-oe-cache-18.17/oe-npm-cache	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,77 @@
++#!/usr/bin/env node
++
++/// Usage: oe-npm-cache <cache-dir> <type> <key> <file-name>
++///    <type> ... meta - metainformation about package
++///               tgz  - tarball
++
++const process = require("node:process");
++
++module.paths.unshift("@@libdir@@/node_modules/npm/node_modules");
++
++const cacache = require('cacache')
++const fs = require('fs')
++
++// argv[0] is 'node', argv[1] is this script
++const cache_dir = process.argv[2]
++const type      = process.argv[3]
++const key       = process.argv[4]
++const file      = process.argv[5]
++
++const data = fs.readFileSync(file)
++
++// metadata content is highly nodejs dependent; when cache entries are not
++// found, place debug statements in 'make-fetch-happen/lib/cache/policy.js'
++// (CachePolicy::satisfies())
++const xlate = {
++    'meta': {
++	'key_prefix': 'make-fetch-happen:request-cache:',
++	'metadata': function() {
++	    return {
++		time: Date.now(),
++		url:  key,
++		reqHeaders: {
++		    'accept': 'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*',
++		},
++		resHeaders: {
++		    "content-type": "application/json",
++		    "status": 200,
++		},
++		options: {
++		    compress: true,
++		}
++	    };
++	},
++    },
++
++    'tgz': {
++	'key_prefix': 'make-fetch-happen:request-cache:',
++	'metadata': function() {
++	    return {
++		time: Date.now(),
++		url:  key,
++		reqHeaders: {
++		    'accept': '*/*',
++		},
++		resHeaders: {
++		    "content-type": "application/octet-stream",
++		    "status": 200,
++		},
++		options: {
++		    compress: true,
++		},
++	    };
++	},
++    },
++};
++
++const info = xlate[type];
++let opts = {}
++
++if (info.metadata) {
++    opts['metadata'] = info.metadata();
++}
++
++cacache.put(cache_dir, info.key_prefix + key, data, opts)
++    .then(integrity => {
++	console.log(`Saved content of ${key} (${file}).`);
++})
+diff -Naur a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs-oe-cache-native_18.17.bb b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs-oe-cache-native_18.17.bb
+--- a/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs-oe-cache-native_18.17.bb	1970-01-01 01:00:00.000000000 +0100
++++ b/meta-openembedded/meta-oe/recipes-devtools/nodejs_18.17.1/nodejs-oe-cache-native_18.17.bb	2024-08-02 09:22:58.247987887 +0200
+@@ -0,0 +1,21 @@
++DESCRIPTION = "OE helper for manipulating npm cache"
++LICENSE = "Apache-2.0"
++LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
++
++SRC_URI = "\
++    file://oe-npm-cache \
++"
++
++inherit native
++
++B = "${WORKDIR}/build"
++
++do_configure() {
++    sed -e 's!@@libdir@@!${libdir}!g' < '${WORKDIR}/oe-npm-cache' > '${B}/oe-npm-cache'
++}
++
++do_install() {
++    install -D -p -m 0755 ${B}/oe-npm-cache ${D}${bindir}/oe-npm-cache
++}
++
++RDEPENDS:${PN} = "nodejs-native"
+diff -Naur a/poky/meta/recipes-support/icu/icu/0001-Fix-big-endian-build.patch b/poky/meta/recipes-support/icu/icu/0001-Fix-big-endian-build.patch
+--- a/poky/meta/recipes-support/icu/icu/0001-Fix-big-endian-build.patch	2024-06-21 09:02:06.000000000 +0200
++++ b/poky/meta/recipes-support/icu/icu/0001-Fix-big-endian-build.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,28 +0,0 @@
+-From 9be0b489a94b57419202c552022f25cb95bfac51 Mon Sep 17 00:00:00 2001
+-From: Alexander Kanavin <alex.kanavin@gmail.com>
+-Date: Wed, 17 Apr 2019 16:41:58 +0200
+-Subject: [PATCH] Fix big-endian build
+-
+-Bug-report: https://unicode-org.atlassian.net/browse/ICU-20533
+-Patch taken from: https://bugs.gentoo.org/682170
+-
+-it is applied upstream and will be in version 67+
+-
+-Upstream-Status: Backport [https://github.com/unicode-org/icu/commit/4a3a457b38cd828b7b3fa4fdbc6e2504a57275e9]
+-Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+----
+- data/Makefile.in | 3 ++-
+- 1 file changed, 2 insertions(+), 1 deletion(-)
+-
+---- a/data/Makefile.in
+-+++ b/data/Makefile.in
+-@@ -148,7 +148,8 @@ ICUDATA_ARCHIVE = $(firstword $(wildcard
+- # and convert it to the current type.
+- ifneq ($(ICUDATA_ARCHIVE),)
+- ICUDATA_SOURCE_ARCHIVE = $(OUTDIR)/$(ICUDATA_PLATFORM_NAME).dat
+--$(ICUDATA_SOURCE_ARCHIVE): $(ICUDATA_ARCHIVE) $(OUTDIR)
+-+$(ICUDATA_SOURCE_ARCHIVE): $(ICUDATA_ARCHIVE)
+-+	$(MKINSTALLDIRS) $(OUTDIR)
+- 	$(INVOKE) $(TOOLBINDIR)/icupkg -t$(ICUDATA_CHAR) $(ICUDATA_ARCHIVE) $(ICUDATA_SOURCE_ARCHIVE)
+- endif
+- else
+diff -Naur a/poky/meta/recipes-support/icu/icu/0001-icu-Added-armeb-support.patch b/poky/meta/recipes-support/icu/icu/0001-icu-Added-armeb-support.patch
+--- a/poky/meta/recipes-support/icu/icu/0001-icu-Added-armeb-support.patch	2024-06-21 09:02:06.000000000 +0200
++++ b/poky/meta/recipes-support/icu/icu/0001-icu-Added-armeb-support.patch	2024-08-02 09:23:13.280222683 +0200
+@@ -1,4 +1,4 @@
+-From 500321387ceca48934bb0f323779117cd518bab6 Mon Sep 17 00:00:00 2001
++From e3c25af4b40d64f098e7b8ae5a91fdc3c90163c4 Mon Sep 17 00:00:00 2001
+ From: Lei Maohui <leimaohui@cn.fujitsu.com>
+ Date: Wed, 8 May 2019 14:42:30 +0900
+ Subject: [PATCH] icu: Added armeb support.
+@@ -8,15 +8,16 @@
+ Upstream-Status: Pending
+ 
+ Signed-off-by: Lei Maohui <leimaohui@cn.fujitsu.com>
++
+ ---
+  i18n/double-conversion-utils.h | 2 +-
+  1 file changed, 1 insertion(+), 1 deletion(-)
+ 
+-diff --git a/i18n/double-conversion-utils.h b/i18n/double-conversion-utils.h
+-index 1e44fca..e4f2a8b 100644
++diff --git a/source/i18n/double-conversion-utils.h b/source/i18n/double-conversion-utils.h
++index 7f23e0a..7f89094 100644
+ --- a/i18n/double-conversion-utils.h
+ +++ b/i18n/double-conversion-utils.h
+-@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
++@@ -115,7 +115,7 @@ int main(int argc, char** argv) {
+  //
+  // If it prints "correct" then the architecture should be here, in the "correct" section.
+  #if defined(_M_X64) || defined(__x86_64__) || \
+@@ -24,7 +25,4 @@
+ +    defined(__arm__) || defined(__avr32__) || defined(_M_ARM) || defined(_M_ARM64) || \
+      defined(__hppa__) || defined(__ia64__) || \
+      defined(__mips__) || \
+-     defined(__powerpc__) || defined(__ppc__) || defined(__ppc64__) || \
+--- 
+-2.7.4
+-
++     defined(__loongarch__) || \
+diff -Naur a/poky/meta/recipes-support/icu/icu/0002-ICU-21175-Add-cnvalias-as-a-dependency-of-misc_res.patch b/poky/meta/recipes-support/icu/icu/0002-ICU-21175-Add-cnvalias-as-a-dependency-of-misc_res.patch
+--- a/poky/meta/recipes-support/icu/icu/0002-ICU-21175-Add-cnvalias-as-a-dependency-of-misc_res.patch	2024-06-21 09:02:06.000000000 +0200
++++ b/poky/meta/recipes-support/icu/icu/0002-ICU-21175-Add-cnvalias-as-a-dependency-of-misc_res.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,24 +0,0 @@
+-From f2bc064e0d70ac068de4539d069bfab6cdccc48d Mon Sep 17 00:00:00 2001
+-From: "Shane F. Carr" <shane@unicode.org>
+-Date: Fri, 10 Jul 2020 14:28:22 -0500
+-Subject: [PATCH] ICU-21175 Add cnvalias as a dependency of misc_res
+-
+-Upstream-Status: Backport [https://github.com/unicode-org/icu/commit/ee2d8b01034c3101de2bd58f9328daa076995e9e]
+-Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
+----
+- data/BUILDRULES.py | 2 +-
+- 1 file changed, 1 insertion(+), 1 deletion(-)
+-
+-diff --git a/data/BUILDRULES.py b/data/BUILDRULES.py
+-index 2338afd1f7..63b6e09273 100644
+---- a/data/BUILDRULES.py
+-+++ b/data/BUILDRULES.py
+-@@ -361,7 +361,7 @@ def generate_misc(config, io, common_vars):
+-         RepeatedExecutionRequest(
+-             name = "misc_res",
+-             category = "misc",
+--            dep_targets = [],
+-+            dep_targets = [DepTarget("cnvalias")], # ICU-21175
+-             input_files = input_files,
+-             output_files = output_files,
+-             tool = IcuTool("genrb"),
+diff -Naur a/poky/meta/recipes-support/icu/icu/CVE-2020-10531.patch b/poky/meta/recipes-support/icu/icu/CVE-2020-10531.patch
+--- a/poky/meta/recipes-support/icu/icu/CVE-2020-10531.patch	2024-06-21 09:02:06.000000000 +0200
++++ b/poky/meta/recipes-support/icu/icu/CVE-2020-10531.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,128 +0,0 @@
+-From b7d08bc04a4296982fcef8b6b8a354a9e4e7afca Mon Sep 17 00:00:00 2001
+-From: Frank Tang <ftang@chromium.org>
+-Date: Sat, 1 Feb 2020 02:39:04 +0000
+-Subject: [PATCH] ICU-20958 Prevent SEGV_MAPERR in append
+-
+-See #971
+-
+-Upstream-Status: Accepted
+-CVE: CVE-2020-10531
+-
+-Reference to upstream patch:
+-https://github.com/unicode-org/icu/commit/b7d08bc04a4296982fcef8b6b8a354a9e4e7afca
+-
+----
+- common/unistr.cpp          |  6 ++-
+- test/intltest/ustrtest.cpp | 62 +++++++++++++++++++++++++++++++
+- test/intltest/ustrtest.h   |  1 +
+- 3 files changed, 68 insertions(+), 1 deletion(-)
+-
+-diff --git a/common/unistr.cpp b/common/unistr.cpp
+-index 901bb33..6ea0915 100644
+---- a/common/unistr.cpp
+-+++ b/common/unistr.cpp
+-@@ -1563,7 +1563,11 @@ UnicodeString::doAppend(const UChar *srcChars, int32_t srcStart, int32_t srcLeng
+-   }
+- 
+-   int32_t oldLength = length();
+--  int32_t newLength = oldLength + srcLength;
+-+  int32_t newLength; 
+-+  if (uprv_add32_overflow(oldLength, srcLength, &newLength)) { 
+-+     setToBogus(); 
+-+     return *this; 
+-+  }
+- 
+-   // Check for append onto ourself
+-   const UChar* oldArray = getArrayStart();
+-diff --git a/test/intltest/ustrtest.cpp b/test/intltest/ustrtest.cpp
+-index b6515ea..ad38bdf 100644
+---- a/test/intltest/ustrtest.cpp
+-+++ b/test/intltest/ustrtest.cpp
+-@@ -67,6 +67,7 @@ void UnicodeStringTest::runIndexedTest( int32_t index, UBool exec, const char* &
+-     TESTCASE_AUTO(TestWCharPointers);
+-     TESTCASE_AUTO(TestNullPointers);
+-     TESTCASE_AUTO(TestUnicodeStringInsertAppendToSelf);
+-+    TESTCASE_AUTO(TestLargeAppend);
+-     TESTCASE_AUTO_END;
+- }
+- 
+-@@ -2310,3 +2311,64 @@ void UnicodeStringTest::TestUnicodeStringInsertAppendToSelf() {
+-     str.insert(2, sub);
+-     assertEquals("", u"abbcdcde", str);
+- }
+-+
+-+void UnicodeStringTest::TestLargeAppend() {
+-+    if(quick) return;
+-+
+-+    IcuTestErrorCode status(*this, "TestLargeAppend");
+-+    // Make a large UnicodeString
+-+    int32_t len = 0xAFFFFFF;
+-+    UnicodeString str;
+-+    char16_t *buf = str.getBuffer(len);
+-+    // A fast way to set buffer to valid Unicode.
+-+    // 4E4E is a valid unicode character
+-+    uprv_memset(buf, 0x4e, len * 2);
+-+    str.releaseBuffer(len);
+-+    UnicodeString dest;
+-+    // Append it 16 times
+-+    // 0xAFFFFFF times 16 is 0xA4FFFFF1,
+-+    // which is greater than INT32_MAX, which is 0x7FFFFFFF.
+-+    int64_t total = 0;
+-+    for (int32_t i = 0; i < 16; i++) {
+-+        dest.append(str);
+-+        total += len;
+-+        if (total <= INT32_MAX) {
+-+            assertFalse("dest is not bogus", dest.isBogus());
+-+        } else {
+-+            assertTrue("dest should be bogus", dest.isBogus());
+-+        }
+-+    }
+-+    dest.remove();
+-+    total = 0;
+-+    for (int32_t i = 0; i < 16; i++) {
+-+        dest.append(str);
+-+        total += len;
+-+        if (total + len <= INT32_MAX) {
+-+            assertFalse("dest is not bogus", dest.isBogus());
+-+        } else if (total <= INT32_MAX) {
+-+            // Check that a string of exactly the maximum size works
+-+            UnicodeString str2;
+-+            int32_t remain = INT32_MAX - total;
+-+            char16_t *buf2 = str2.getBuffer(remain);
+-+            if (buf2 == nullptr) {
+-+                // if somehow memory allocation fail, return the test
+-+                return;
+-+            }
+-+            uprv_memset(buf2, 0x4e, remain * 2);
+-+            str2.releaseBuffer(remain);
+-+            dest.append(str2);
+-+            total += remain;
+-+            assertEquals("When a string of exactly the maximum size works", (int64_t)INT32_MAX, total);
+-+            assertEquals("When a string of exactly the maximum size works", INT32_MAX, dest.length());
+-+            assertFalse("dest is not bogus", dest.isBogus());
+-+
+-+            // Check that a string size+1 goes bogus
+-+            str2.truncate(1);
+-+            dest.append(str2);
+-+            total++;
+-+            assertTrue("dest should be bogus", dest.isBogus());
+-+        } else {
+-+            assertTrue("dest should be bogus", dest.isBogus());
+-+        }
+-+    }
+-+}
+-diff --git a/test/intltest/ustrtest.h b/test/intltest/ustrtest.h
+-index 218befd..4a356a9 100644
+---- a/test/intltest/ustrtest.h
+-+++ b/test/intltest/ustrtest.h
+-@@ -97,6 +97,7 @@ public:
+-     void TestWCharPointers();
+-     void TestNullPointers();
+-     void TestUnicodeStringInsertAppendToSelf();
+-+    void TestLargeAppend();
+- };
+- 
+- #endif
+--- 
+-2.17.1
+-
+diff -Naur a/poky/meta/recipes-support/icu/icu/icu-pkgdata-large-cmd.patch b/poky/meta/recipes-support/icu/icu/icu-pkgdata-large-cmd.patch
+--- a/poky/meta/recipes-support/icu/icu/icu-pkgdata-large-cmd.patch	2024-06-21 09:02:06.000000000 +0200
++++ b/poky/meta/recipes-support/icu/icu/icu-pkgdata-large-cmd.patch	1970-01-01 01:00:00.000000000 +0100
+@@ -1,49 +0,0 @@
+-pkgdata.cpp: use LARGE_BUFFER_MAX_SIZE for cmd
+-
+-Use LARGE_BUFFER_MAX_SIZE for cmd rather than SMALL_BUFFER_MAX_SIZE,
+-otherwise there was a Segmentation fault error when the command line is
+-long, this should be a misplay since other cmd uses
+-LARGE_BUFFER_MAX_SIZE.
+-
+-Upstream-Status: Pending
+-
+-Signed-off-by: Robert Yang <liezhi.yang@windriver.com>
+-Signed-off-by: Jackie Huang <jackie.huang@windriver.com>
+----
+- tools/pkgdata/pkgdata.cpp | 6 +++---
+- 1 file changed, 3 insertions(+), 3 deletions(-)
+-
+-diff --git a/tools/pkgdata/pkgdata.cpp b/tools/pkgdata/pkgdata.cpp
+-index 60167dd..506dd32 100644
+---- a/tools/pkgdata/pkgdata.cpp
+-+++ b/tools/pkgdata/pkgdata.cpp
+-@@ -1084,7 +1084,7 @@ normal_symlink_mode:
+- 
+- static int32_t pkg_installLibrary(const char *installDir, const char *targetDir, UBool noVersion) {
+-     int32_t result = 0;
+--    char cmd[SMALL_BUFFER_MAX_SIZE];
+-+    char cmd[LARGE_BUFFER_MAX_SIZE];
+- 
+-     sprintf(cmd, "cd %s && %s %s %s%s%s",
+-             targetDir,
+-@@ -1152,7 +1152,7 @@ static int32_t pkg_installLibrary(const char *installDir, const char *targetDir,
+- 
+- static int32_t pkg_installCommonMode(const char *installDir, const char *fileName) {
+-     int32_t result = 0;
+--    char cmd[SMALL_BUFFER_MAX_SIZE] = "";
+-+    char cmd[LARGE_BUFFER_MAX_SIZE] = "";
+- 
+-     if (!T_FileStream_file_exists(installDir)) {
+-         UErrorCode status = U_ZERO_ERROR;
+-@@ -1184,7 +1184,7 @@ static int32_t pkg_installCommonMode(const char *installDir, const char *fileNam
+- #endif
+- static int32_t pkg_installFileMode(const char *installDir, const char *srcDir, const char *fileListName) {
+-     int32_t result = 0;
+--    char cmd[SMALL_BUFFER_MAX_SIZE] = "";
+-+    char cmd[LARGE_BUFFER_MAX_SIZE] = "";
+- 
+-     if (!T_FileStream_file_exists(installDir)) {
+-         UErrorCode status = U_ZERO_ERROR;
+--- 
+-1.9.1
+-
+diff -Naur a/poky/meta/recipes-support/icu/icu_66.1.bb b/poky/meta/recipes-support/icu/icu_66.1.bb
+--- a/poky/meta/recipes-support/icu/icu_66.1.bb	2024-06-21 09:02:06.000000000 +0200
++++ b/poky/meta/recipes-support/icu/icu_66.1.bb	1970-01-01 01:00:00.000000000 +0100
+@@ -1,71 +0,0 @@
+-require icu.inc
+-
+-LIC_FILES_CHKSUM = "file://../LICENSE;md5=a3808a5b70071b07f87ff2205e4d75a0"
+-
+-def icu_download_version(d):
+-    pvsplit = d.getVar('PV').split('.')
+-    return pvsplit[0] + "_" + pvsplit[1]
+-
+-def icu_download_folder(d):
+-    pvsplit = d.getVar('PV').split('.')
+-    return pvsplit[0] + "-" + pvsplit[1]
+-
+-ICU_PV = "${@icu_download_version(d)}"
+-ICU_FOLDER = "${@icu_download_folder(d)}"
+-
+-# http://errors.yoctoproject.org/Errors/Details/20486/
+-ARM_INSTRUCTION_SET_armv4 = "arm"
+-ARM_INSTRUCTION_SET_armv5 = "arm"
+-
+-BASE_SRC_URI = "https://github.com/unicode-org/icu/releases/download/release-${ICU_FOLDER}/icu4c-${ICU_PV}-src.tgz"
+-DATA_SRC_URI = "https://github.com/unicode-org/icu/releases/download/release-${ICU_FOLDER}/icu4c-${ICU_PV}-data.zip"
+-SRC_URI = "${BASE_SRC_URI};name=code \
+-           ${DATA_SRC_URI};name=data \
+-           file://0001-Fix-big-endian-build.patch;patchdir=${WORKDIR} \
+-           file://0002-ICU-21175-Add-cnvalias-as-a-dependency-of-misc_res.patch;patchdir=${WORKDIR} \
+-           file://filter.json \
+-           file://icu-pkgdata-large-cmd.patch \
+-           file://fix-install-manx.patch \
+-           file://0001-icu-Added-armeb-support.patch \
+-           file://CVE-2020-10531.patch \
+-           "
+-
+-SRC_URI_append_class-target = "\
+-           file://0001-Disable-LDFLAGSICUDT-for-Linux.patch \
+-          "
+-SRC_URI[code.sha256sum] = "52a3f2209ab95559c1cf0a14f24338001f389615bf00e2585ef3dbc43ecf0a2e"
+-SRC_URI[data.sha256sum] = "8be647f738891d2beb79d48f99077b3499948430eae6f1be112553b15ab0243e"
+-
+-UPSTREAM_CHECK_REGEX = "icu4c-(?P<pver>\d+(_\d+)+)-src"
+-UPSTREAM_CHECK_URI = "https://github.com/unicode-org/icu/releases"
+-
+-EXTRA_OECONF_append_libc-musl = " ac_cv_func_strtod_l=no"
+-
+-PACKAGECONFIG ?= ""
+-PACKAGECONFIG[make-icudata] = ",,,"
+-
+-do_make_icudata_class-target () {
+-    cd ${S}
+-    rm -rf data
+-    cp -a ${WORKDIR}/data .
+-    ${@bb.utils.contains('PACKAGECONFIG', 'make-icudata', '', 'exit 0', d)}
+-    AR='${BUILD_AR}' \
+-    CC='${BUILD_CC}' \
+-    CPP='${BUILD_CPP}' \
+-    CXX='${BUILD_CXX}' \
+-    RANLIB='${BUILD_RANLIB}' \
+-    CFLAGS='${BUILD_CFLAGS}' \
+-    CPPFLAGS='${BUILD_CPPFLAGS}' \
+-    CXXFLAGS='${BUILD_CXXFLAGS}' \
+-    LDFLAGS='${BUILD_LDFLAGS}' \
+-    ICU_DATA_FILTER_FILE=${WORKDIR}/filter.json \
+-    ./runConfigureICU Linux --with-data-packaging=archive
+-    oe_runmake
+-    install -Dm644 ${S}/data/out/icudt${ICU_MAJOR_VER}l.dat ${S}/data/in/icudt${ICU_MAJOR_VER}l.dat
+-}
+-
+-do_make_icudata() {
+-    :
+-}
+-
+-addtask make_icudata before do_configure after do_patch
+diff -Naur a/poky/meta/recipes-support/icu/icu_70.1.bb b/poky/meta/recipes-support/icu/icu_70.1.bb
+--- a/poky/meta/recipes-support/icu/icu_70.1.bb	1970-01-01 01:00:00.000000000 +0100
++++ b/poky/meta/recipes-support/icu/icu_70.1.bb	2024-08-02 09:23:13.280222683 +0200
+@@ -0,0 +1,150 @@
++SUMMARY = "International Component for Unicode libraries"
++DESCRIPTION = "The International Component for Unicode (ICU) is a mature, \
++portable set of C/C++ and Java libraries for Unicode support, software \
++internationalization (I18N) and globalization (G11N), giving applications the \
++same results on all platforms."
++HOMEPAGE = "http://site.icu-project.org/"
++
++LICENSE = "ICU"
++DEPENDS = "icu-native autoconf-archive"
++DEPENDS_class-native = "autoconf-archive-native"
++
++CVE_PRODUCT = "international_components_for_unicode"
++
++S = "${WORKDIR}/icu/source"
++SPDX_S = "${WORKDIR}/icu"
++STAGING_ICU_DIR_NATIVE = "${STAGING_DATADIR_NATIVE}/${BPN}/${PV}"
++
++BINCONFIG = "${bindir}/icu-config"
++
++ICU_MAJOR_VER = "${@d.getVar('PV').split('.')[0]}"
++
++inherit autotools pkgconfig binconfig multilib_script
++
++MULTILIB_SCRIPTS = "${PN}-dev:${bindir}/icu-config"
++
++# ICU needs the native build directory as an argument to its --with-cross-build option when
++# cross-compiling. Taken the situation that different builds may share a common sstate-cache
++# into consideration, the native build directory needs to be staged.
++EXTRA_OECONF = "--with-cross-build=${STAGING_ICU_DIR_NATIVE}"
++EXTRA_OECONF_class-native = ""
++EXTRA_OECONF_class-nativesdk = "--with-cross-build=${STAGING_ICU_DIR_NATIVE}"
++
++EXTRA_OECONF_append_class-target = "${@oe.utils.conditional('SITEINFO_ENDIANNESS', 'be', ' --with-data-packaging=archive', '', d)}"
++TARGET_CXXFLAGS_append = "${@oe.utils.conditional('SITEINFO_ENDIANNESS', 'be', ' -DICU_DATA_DIR=\\""${datadir}/${BPN}/${PV}\\""', '', d)}"
++
++ASNEEDED = ""
++
++do_compile_prepend_class-target () {
++	# Make sure certain build host references do not end up being compiled
++	# in the image. This only affects libicutu and icu-dbg
++	sed  \
++	    -e 's,DU_BUILD=,DU_BUILD_unused=,g' \
++	    -e '/^CPPFLAGS.*/ s,--sysroot=${STAGING_DIR_TARGET},,g' \
++	    -i ${B}/tools/toolutil/Makefile
++}
++
++PREPROCESS_RELOCATE_DIRS = "${datadir}/${BPN}/${PV}"
++do_install_append_class-native() {
++	mkdir -p ${D}/${STAGING_ICU_DIR_NATIVE}/config
++	cp -r ${B}/config/icucross.mk ${D}/${STAGING_ICU_DIR_NATIVE}/config
++	cp -r ${B}/config/icucross.inc ${D}/${STAGING_ICU_DIR_NATIVE}/config
++	cp -r ${B}/lib ${D}/${STAGING_ICU_DIR_NATIVE}
++	cp -r ${B}/bin ${D}/${STAGING_ICU_DIR_NATIVE}
++	cp -r ${B}/tools ${D}/${STAGING_ICU_DIR_NATIVE}
++}
++
++do_install_append_class-target() {
++    # The native pkgdata can not generate the correct data file.
++    # Use icupkg to re-generate it.
++    if [ "${SITEINFO_ENDIANNESS}" = "be" ] ; then
++        rm -f ${D}/${datadir}/${BPN}/${PV}/icudt${ICU_MAJOR_VER}b.dat
++        icupkg -tb ${S}/data/in/icudt${ICU_MAJOR_VER}l.dat ${D}/${datadir}/${BPN}/${PV}/icudt${ICU_MAJOR_VER}b.dat
++    fi
++	
++	# Remove build host references...
++	sed -i  \
++	    -e 's,--sysroot=${STAGING_DIR_TARGET},,g' \
++	    -e 's|${DEBUG_PREFIX_MAP}||g' \
++	    -e 's:${HOSTTOOLS_DIR}/::g' \
++	    ${D}/${bindir}/icu-config ${D}/${libdir}/${BPN}/${PV}/Makefile.inc \
++	    ${D}/${libdir}/${BPN}/${PV}/pkgdata.inc
++}
++
++PACKAGES =+ "libicudata libicuuc libicui18n libicutu libicuio"
++
++FILES_${PN}-dev += "${libdir}/${BPN}/"
++
++FILES_libicudata = "${libdir}/libicudata.so.*"
++FILES_libicuuc = "${libdir}/libicuuc.so.*"
++FILES_libicui18n = "${libdir}/libicui18n.so.*"
++FILES_libicutu = "${libdir}/libicutu.so.*"
++FILES_libicuio = "${libdir}/libicuio.so.*"
++
++BBCLASSEXTEND = "native nativesdk"
++
++LIC_FILES_CHKSUM = "file://../LICENSE;md5=dc9d616e558490c389609a0e8b81ae6d"
++
++def icu_download_version(d):
++    pvsplit = d.getVar('PV').split('.')
++    return pvsplit[0] + "_" + pvsplit[1]
++
++def icu_download_folder(d):
++    pvsplit = d.getVar('PV').split('.')
++    return pvsplit[0] + "-" + pvsplit[1]
++
++ICU_PV = "${@icu_download_version(d)}"
++ICU_FOLDER = "${@icu_download_folder(d)}"
++
++# http://errors.yoctoproject.org/Errors/Details/20486/
++ARM_INSTRUCTION_SET_armv4 = "arm"
++ARM_INSTRUCTION_SET_armv5 = "arm"
++
++BASE_SRC_URI = "https://github.com/unicode-org/icu/releases/download/release-${ICU_FOLDER}/icu4c-${ICU_PV}-src.tgz"
++DATA_SRC_URI = "https://github.com/unicode-org/icu/releases/download/release-${ICU_FOLDER}/icu4c-${ICU_PV}-data.zip"
++SRC_URI = "${BASE_SRC_URI};name=code \
++           ${DATA_SRC_URI};name=data \
++           file://filter.json \
++           file://fix-install-manx.patch \
++           file://0001-icu-Added-armeb-support.patch \
++           "
++
++SRC_URI_append_class-target = "\
++           file://0001-Disable-LDFLAGSICUDT-for-Linux.patch \
++          "
++SRC_URI[code.sha256sum] = "8d205428c17bf13bb535300669ed28b338a157b1c01ae66d31d0d3e2d47c3fd5"
++SRC_URI[data.sha256sum] = "c72723ddba3300ffb231d6b09e2a728ea6e89de10ed5927f74bacbd77042336e"
++
++UPSTREAM_CHECK_REGEX = "icu4c-(?P<pver>\d+(_\d+)+)-src"
++UPSTREAM_CHECK_URI = "https://github.com/unicode-org/icu/releases"
++
++EXTRA_OECONF_append_libc-musl = " ac_cv_func_strtod_l=no"
++
++PACKAGECONFIG ?= ""
++PACKAGECONFIG[make-icudata] = ",,,"
++
++do_make_icudata_class-target () {
++    ${@bb.utils.contains('PACKAGECONFIG', 'make-icudata', '', 'exit 0', d)}
++    cd ${S}
++    rm -rf data
++    cp -a ${WORKDIR}/data .
++    AR='${BUILD_AR}' \
++    CC='${BUILD_CC}' \
++    CPP='${BUILD_CPP}' \
++    CXX='${BUILD_CXX}' \
++    RANLIB='${BUILD_RANLIB}' \
++    CFLAGS='${BUILD_CFLAGS}' \
++    CPPFLAGS='${BUILD_CPPFLAGS}' \
++    CXXFLAGS='${BUILD_CXXFLAGS}' \
++    LDFLAGS='${BUILD_LDFLAGS}' \
++    ICU_DATA_FILTER_FILE=${WORKDIR}/filter.json \
++    ./runConfigureICU Linux --with-data-packaging=archive
++    oe_runmake
++    install -Dm644 ${S}/data/out/icudt${ICU_MAJOR_VER}l.dat ${S}/data/in/icudt${ICU_MAJOR_VER}l.dat
++}
++
++do_make_icudata() {
++    :
++}
++
++addtask make_icudata before do_configure after do_patch do_prepare_recipe_sysroot
+diff -Naur a/poky/meta/recipes-support/icu/icu.inc b/poky/meta/recipes-support/icu/icu.inc
+--- a/poky/meta/recipes-support/icu/icu.inc	2024-06-21 09:02:06.000000000 +0200
++++ b/poky/meta/recipes-support/icu/icu.inc	1970-01-01 01:00:00.000000000 +0100
+@@ -1,86 +0,0 @@
+-SUMMARY = "International Component for Unicode libraries"
+-DESCRIPTION = "The International Component for Unicode (ICU) is a mature, \
+-portable set of C/C++ and Java libraries for Unicode support, software \
+-internationalization (I18N) and globalization (G11N), giving applications the \
+-same results on all platforms."
+-HOMEPAGE = "http://site.icu-project.org/"
+-
+-LICENSE = "ICU"
+-DEPENDS = "icu-native"
+-DEPENDS_class-native = ""
+-
+-CVE_PRODUCT = "international_components_for_unicode"
+-
+-S = "${WORKDIR}/icu/source"
+-SPDX_S = "${WORKDIR}/icu"
+-STAGING_ICU_DIR_NATIVE = "${STAGING_DATADIR_NATIVE}/${BPN}/${PV}"
+-
+-BINCONFIG = "${bindir}/icu-config"
+-
+-ICU_MAJOR_VER = "${@d.getVar('PV').split('.')[0]}"
+-
+-inherit autotools pkgconfig binconfig multilib_script
+-
+-MULTILIB_SCRIPTS = "${PN}-dev:${bindir}/icu-config"
+-
+-# ICU needs the native build directory as an argument to its --with-cross-build option when
+-# cross-compiling. Taken the situation that different builds may share a common sstate-cache
+-# into consideration, the native build directory needs to be staged.
+-EXTRA_OECONF = "--with-cross-build=${STAGING_ICU_DIR_NATIVE}"
+-EXTRA_OECONF_class-native = ""
+-EXTRA_OECONF_class-nativesdk = "--with-cross-build=${STAGING_ICU_DIR_NATIVE}"
+-
+-EXTRA_OECONF_append_class-target = "${@oe.utils.conditional('SITEINFO_ENDIANNESS', 'be', ' --with-data-packaging=archive', '', d)}"
+-TARGET_CXXFLAGS_append = "${@oe.utils.conditional('SITEINFO_ENDIANNESS', 'be', ' -DICU_DATA_DIR=\\""${datadir}/${BPN}/${PV}\\""', '', d)}"
+-
+-ASNEEDED = ""
+-
+-do_compile_prepend_class-target () {
+-	# Make sure certain build host references do not end up being compiled
+-	# in the image. This only affects libicutu and icu-dbg
+-	sed  \
+-	    -e 's,DU_BUILD=,DU_BUILD_unused=,g' \
+-	    -e '/^CPPFLAGS.*/ s,--sysroot=${STAGING_DIR_TARGET},,g' \
+-	    -i ${B}/tools/toolutil/Makefile
+-}
+-
+-PREPROCESS_RELOCATE_DIRS = "${datadir}/${BPN}/${PV}"
+-do_install_append_class-native() {
+-	mkdir -p ${D}/${STAGING_ICU_DIR_NATIVE}/config
+-	cp -r ${B}/config/icucross.mk ${D}/${STAGING_ICU_DIR_NATIVE}/config
+-	cp -r ${B}/config/icucross.inc ${D}/${STAGING_ICU_DIR_NATIVE}/config
+-	cp -r ${B}/lib ${D}/${STAGING_ICU_DIR_NATIVE}
+-	cp -r ${B}/bin ${D}/${STAGING_ICU_DIR_NATIVE}
+-	cp -r ${B}/tools ${D}/${STAGING_ICU_DIR_NATIVE}
+-}
+-
+-do_install_append_class-target() {
+-    # The native pkgdata can not generate the correct data file.
+-    # Use icupkg to re-generate it.
+-    if [ "${SITEINFO_ENDIANNESS}" = "be" ] ; then
+-        rm -f ${D}/${datadir}/${BPN}/${PV}/icudt${ICU_MAJOR_VER}b.dat
+-	if [ -f ${S}/data/in/icudt${ICU_MAJOR_VER}l.dat ]; then
+-		icupkg -tb ${S}/data/in/icudt${ICU_MAJOR_VER}l.dat ${D}/${datadir}/${BPN}/${PV}/icudt${ICU_MAJOR_VER}b.dat
+-	fi
+-    fi
+-	
+-	# Remove build host references...
+-	sed -i  \
+-	    -e 's,--sysroot=${STAGING_DIR_TARGET},,g' \
+-	    -e 's|${DEBUG_PREFIX_MAP}||g' \
+-	    -e 's:${HOSTTOOLS_DIR}/::g' \
+-	    ${D}/${bindir}/icu-config ${D}/${libdir}/${BPN}/${PV}/Makefile.inc \
+-	    ${D}/${libdir}/${BPN}/${PV}/pkgdata.inc
+-}
+-
+-PACKAGES =+ "libicudata libicuuc libicui18n libicutu libicuio"
+-
+-FILES_${PN}-dev += "${libdir}/${BPN}/"
+-
+-FILES_libicudata = "${libdir}/libicudata.so.*"
+-FILES_libicuuc = "${libdir}/libicuuc.so.*"
+-FILES_libicui18n = "${libdir}/libicui18n.so.*"
+-FILES_libicutu = "${libdir}/libicutu.so.*"
+-FILES_libicuio = "${libdir}/libicuio.so.*"
+-
+-BBCLASSEXTEND = "native nativesdk"
+diff -Naur a/poky/meta/recipes-support/icu_66.1/icu/0001-Disable-LDFLAGSICUDT-for-Linux.patch b/poky/meta/recipes-support/icu_66.1/icu/0001-Disable-LDFLAGSICUDT-for-Linux.patch
+--- a/poky/meta/recipes-support/icu_66.1/icu/0001-Disable-LDFLAGSICUDT-for-Linux.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/poky/meta/recipes-support/icu_66.1/icu/0001-Disable-LDFLAGSICUDT-for-Linux.patch	2024-08-02 09:23:13.280222683 +0200
+@@ -0,0 +1,28 @@
++From 0c82d6aa02c08e41b13c83b14782bd7024e25d59 Mon Sep 17 00:00:00 2001
++From: Khem Raj <raj.khem@gmail.com>
++Date: Sat, 15 Feb 2014 21:06:42 +0000
++Subject: [PATCH] Disable LDFLAGSICUDT for Linux
++
++Upstream-Status: Inappropriate [ OE Configuration ]
++
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++---
++ source/config/mh-linux |    2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/config/mh-linux b/config/mh-linux
++index 366f0cc..2689aab 100644
++--- a/config/mh-linux
+++++ b/config/mh-linux
++@@ -21,7 +21,7 @@ LD_RPATH= -Wl,-zorigin,-rpath,'$$'ORIGIN
++ LD_RPATH_PRE = -Wl,-rpath,
++ 
++ ## These are the library specific LDFLAGS
++-LDFLAGSICUDT=-nodefaultlibs -nostdlib
+++# LDFLAGSICUDT=-nodefaultlibs -nostdlib
++ 
++ ## Compiler switch to embed a library name
++ # The initial tab in the next line is to prevent icu-config from reading it.
++-- 
++1.7.10.4
++
+diff -Naur a/poky/meta/recipes-support/icu_66.1/icu/0001-Fix-big-endian-build.patch b/poky/meta/recipes-support/icu_66.1/icu/0001-Fix-big-endian-build.patch
+--- a/poky/meta/recipes-support/icu_66.1/icu/0001-Fix-big-endian-build.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/poky/meta/recipes-support/icu_66.1/icu/0001-Fix-big-endian-build.patch	2024-08-02 09:23:13.280222683 +0200
+@@ -0,0 +1,28 @@
++From 9be0b489a94b57419202c552022f25cb95bfac51 Mon Sep 17 00:00:00 2001
++From: Alexander Kanavin <alex.kanavin@gmail.com>
++Date: Wed, 17 Apr 2019 16:41:58 +0200
++Subject: [PATCH] Fix big-endian build
++
++Bug-report: https://unicode-org.atlassian.net/browse/ICU-20533
++Patch taken from: https://bugs.gentoo.org/682170
++
++it is applied upstream and will be in version 67+
++
++Upstream-Status: Backport [https://github.com/unicode-org/icu/commit/4a3a457b38cd828b7b3fa4fdbc6e2504a57275e9]
++Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
++---
++ data/Makefile.in | 3 ++-
++ 1 file changed, 2 insertions(+), 1 deletion(-)
++
++--- a/data/Makefile.in
+++++ b/data/Makefile.in
++@@ -148,7 +148,8 @@ ICUDATA_ARCHIVE = $(firstword $(wildcard
++ # and convert it to the current type.
++ ifneq ($(ICUDATA_ARCHIVE),)
++ ICUDATA_SOURCE_ARCHIVE = $(OUTDIR)/$(ICUDATA_PLATFORM_NAME).dat
++-$(ICUDATA_SOURCE_ARCHIVE): $(ICUDATA_ARCHIVE) $(OUTDIR)
+++$(ICUDATA_SOURCE_ARCHIVE): $(ICUDATA_ARCHIVE)
+++	$(MKINSTALLDIRS) $(OUTDIR)
++ 	$(INVOKE) $(TOOLBINDIR)/icupkg -t$(ICUDATA_CHAR) $(ICUDATA_ARCHIVE) $(ICUDATA_SOURCE_ARCHIVE)
++ endif
++ else
+diff -Naur a/poky/meta/recipes-support/icu_66.1/icu/0001-icu-Added-armeb-support.patch b/poky/meta/recipes-support/icu_66.1/icu/0001-icu-Added-armeb-support.patch
+--- a/poky/meta/recipes-support/icu_66.1/icu/0001-icu-Added-armeb-support.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/poky/meta/recipes-support/icu_66.1/icu/0001-icu-Added-armeb-support.patch	2024-08-02 09:23:13.280222683 +0200
+@@ -0,0 +1,30 @@
++From 500321387ceca48934bb0f323779117cd518bab6 Mon Sep 17 00:00:00 2001
++From: Lei Maohui <leimaohui@cn.fujitsu.com>
++Date: Wed, 8 May 2019 14:42:30 +0900
++Subject: [PATCH] icu: Added armeb support.
++
++Make icu support arm32 BE.
++
++Upstream-Status: Pending
++
++Signed-off-by: Lei Maohui <leimaohui@cn.fujitsu.com>
++---
++ i18n/double-conversion-utils.h | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/i18n/double-conversion-utils.h b/i18n/double-conversion-utils.h
++index 1e44fca..e4f2a8b 100644
++--- a/i18n/double-conversion-utils.h
+++++ b/i18n/double-conversion-utils.h
++@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
++ //
++ // If it prints "correct" then the architecture should be here, in the "correct" section.
++ #if defined(_M_X64) || defined(__x86_64__) || \
++-    defined(__ARMEL__) || defined(__avr32__) || defined(_M_ARM) || defined(_M_ARM64) || \
+++    defined(__arm__) || defined(__avr32__) || defined(_M_ARM) || defined(_M_ARM64) || \
++     defined(__hppa__) || defined(__ia64__) || \
++     defined(__mips__) || \
++     defined(__powerpc__) || defined(__ppc__) || defined(__ppc64__) || \
++-- 
++2.7.4
++
+diff -Naur a/poky/meta/recipes-support/icu_66.1/icu/0002-ICU-21175-Add-cnvalias-as-a-dependency-of-misc_res.patch b/poky/meta/recipes-support/icu_66.1/icu/0002-ICU-21175-Add-cnvalias-as-a-dependency-of-misc_res.patch
+--- a/poky/meta/recipes-support/icu_66.1/icu/0002-ICU-21175-Add-cnvalias-as-a-dependency-of-misc_res.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/poky/meta/recipes-support/icu_66.1/icu/0002-ICU-21175-Add-cnvalias-as-a-dependency-of-misc_res.patch	2024-08-02 09:23:13.280222683 +0200
+@@ -0,0 +1,24 @@
++From f2bc064e0d70ac068de4539d069bfab6cdccc48d Mon Sep 17 00:00:00 2001
++From: "Shane F. Carr" <shane@unicode.org>
++Date: Fri, 10 Jul 2020 14:28:22 -0500
++Subject: [PATCH] ICU-21175 Add cnvalias as a dependency of misc_res
++
++Upstream-Status: Backport [https://github.com/unicode-org/icu/commit/ee2d8b01034c3101de2bd58f9328daa076995e9e]
++Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
++---
++ data/BUILDRULES.py | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/data/BUILDRULES.py b/data/BUILDRULES.py
++index 2338afd1f7..63b6e09273 100644
++--- a/data/BUILDRULES.py
+++++ b/data/BUILDRULES.py
++@@ -361,7 +361,7 @@ def generate_misc(config, io, common_vars):
++         RepeatedExecutionRequest(
++             name = "misc_res",
++             category = "misc",
++-            dep_targets = [],
+++            dep_targets = [DepTarget("cnvalias")], # ICU-21175
++             input_files = input_files,
++             output_files = output_files,
++             tool = IcuTool("genrb"),
+diff -Naur a/poky/meta/recipes-support/icu_66.1/icu/CVE-2020-10531.patch b/poky/meta/recipes-support/icu_66.1/icu/CVE-2020-10531.patch
+--- a/poky/meta/recipes-support/icu_66.1/icu/CVE-2020-10531.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/poky/meta/recipes-support/icu_66.1/icu/CVE-2020-10531.patch	2024-08-02 09:23:13.280222683 +0200
+@@ -0,0 +1,128 @@
++From b7d08bc04a4296982fcef8b6b8a354a9e4e7afca Mon Sep 17 00:00:00 2001
++From: Frank Tang <ftang@chromium.org>
++Date: Sat, 1 Feb 2020 02:39:04 +0000
++Subject: [PATCH] ICU-20958 Prevent SEGV_MAPERR in append
++
++See #971
++
++Upstream-Status: Accepted
++CVE: CVE-2020-10531
++
++Reference to upstream patch:
++https://github.com/unicode-org/icu/commit/b7d08bc04a4296982fcef8b6b8a354a9e4e7afca
++
++---
++ common/unistr.cpp          |  6 ++-
++ test/intltest/ustrtest.cpp | 62 +++++++++++++++++++++++++++++++
++ test/intltest/ustrtest.h   |  1 +
++ 3 files changed, 68 insertions(+), 1 deletion(-)
++
++diff --git a/common/unistr.cpp b/common/unistr.cpp
++index 901bb33..6ea0915 100644
++--- a/common/unistr.cpp
+++++ b/common/unistr.cpp
++@@ -1563,7 +1563,11 @@ UnicodeString::doAppend(const UChar *srcChars, int32_t srcStart, int32_t srcLeng
++   }
++ 
++   int32_t oldLength = length();
++-  int32_t newLength = oldLength + srcLength;
+++  int32_t newLength; 
+++  if (uprv_add32_overflow(oldLength, srcLength, &newLength)) { 
+++     setToBogus(); 
+++     return *this; 
+++  }
++ 
++   // Check for append onto ourself
++   const UChar* oldArray = getArrayStart();
++diff --git a/test/intltest/ustrtest.cpp b/test/intltest/ustrtest.cpp
++index b6515ea..ad38bdf 100644
++--- a/test/intltest/ustrtest.cpp
+++++ b/test/intltest/ustrtest.cpp
++@@ -67,6 +67,7 @@ void UnicodeStringTest::runIndexedTest( int32_t index, UBool exec, const char* &
++     TESTCASE_AUTO(TestWCharPointers);
++     TESTCASE_AUTO(TestNullPointers);
++     TESTCASE_AUTO(TestUnicodeStringInsertAppendToSelf);
+++    TESTCASE_AUTO(TestLargeAppend);
++     TESTCASE_AUTO_END;
++ }
++ 
++@@ -2310,3 +2311,64 @@ void UnicodeStringTest::TestUnicodeStringInsertAppendToSelf() {
++     str.insert(2, sub);
++     assertEquals("", u"abbcdcde", str);
++ }
+++
+++void UnicodeStringTest::TestLargeAppend() {
+++    if(quick) return;
+++
+++    IcuTestErrorCode status(*this, "TestLargeAppend");
+++    // Make a large UnicodeString
+++    int32_t len = 0xAFFFFFF;
+++    UnicodeString str;
+++    char16_t *buf = str.getBuffer(len);
+++    // A fast way to set buffer to valid Unicode.
+++    // 4E4E is a valid unicode character
+++    uprv_memset(buf, 0x4e, len * 2);
+++    str.releaseBuffer(len);
+++    UnicodeString dest;
+++    // Append it 16 times
+++    // 0xAFFFFFF times 16 is 0xA4FFFFF1,
+++    // which is greater than INT32_MAX, which is 0x7FFFFFFF.
+++    int64_t total = 0;
+++    for (int32_t i = 0; i < 16; i++) {
+++        dest.append(str);
+++        total += len;
+++        if (total <= INT32_MAX) {
+++            assertFalse("dest is not bogus", dest.isBogus());
+++        } else {
+++            assertTrue("dest should be bogus", dest.isBogus());
+++        }
+++    }
+++    dest.remove();
+++    total = 0;
+++    for (int32_t i = 0; i < 16; i++) {
+++        dest.append(str);
+++        total += len;
+++        if (total + len <= INT32_MAX) {
+++            assertFalse("dest is not bogus", dest.isBogus());
+++        } else if (total <= INT32_MAX) {
+++            // Check that a string of exactly the maximum size works
+++            UnicodeString str2;
+++            int32_t remain = INT32_MAX - total;
+++            char16_t *buf2 = str2.getBuffer(remain);
+++            if (buf2 == nullptr) {
+++                // if somehow memory allocation fail, return the test
+++                return;
+++            }
+++            uprv_memset(buf2, 0x4e, remain * 2);
+++            str2.releaseBuffer(remain);
+++            dest.append(str2);
+++            total += remain;
+++            assertEquals("When a string of exactly the maximum size works", (int64_t)INT32_MAX, total);
+++            assertEquals("When a string of exactly the maximum size works", INT32_MAX, dest.length());
+++            assertFalse("dest is not bogus", dest.isBogus());
+++
+++            // Check that a string size+1 goes bogus
+++            str2.truncate(1);
+++            dest.append(str2);
+++            total++;
+++            assertTrue("dest should be bogus", dest.isBogus());
+++        } else {
+++            assertTrue("dest should be bogus", dest.isBogus());
+++        }
+++    }
+++}
++diff --git a/test/intltest/ustrtest.h b/test/intltest/ustrtest.h
++index 218befd..4a356a9 100644
++--- a/test/intltest/ustrtest.h
+++++ b/test/intltest/ustrtest.h
++@@ -97,6 +97,7 @@ public:
++     void TestWCharPointers();
++     void TestNullPointers();
++     void TestUnicodeStringInsertAppendToSelf();
+++    void TestLargeAppend();
++ };
++ 
++ #endif
++-- 
++2.17.1
++
+diff -Naur a/poky/meta/recipes-support/icu_66.1/icu/filter.json b/poky/meta/recipes-support/icu_66.1/icu/filter.json
+--- a/poky/meta/recipes-support/icu_66.1/icu/filter.json	1970-01-01 01:00:00.000000000 +0100
++++ b/poky/meta/recipes-support/icu_66.1/icu/filter.json	2024-08-02 09:23:13.280222683 +0200
+@@ -0,0 +1,2 @@
++{
++}
+diff -Naur a/poky/meta/recipes-support/icu_66.1/icu/fix-install-manx.patch b/poky/meta/recipes-support/icu_66.1/icu/fix-install-manx.patch
+--- a/poky/meta/recipes-support/icu_66.1/icu/fix-install-manx.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/poky/meta/recipes-support/icu_66.1/icu/fix-install-manx.patch	2024-08-02 09:23:13.280222683 +0200
+@@ -0,0 +1,54 @@
++From a6ddabc8cadb76bfe2d2e374a6702442cfe51cce Mon Sep 17 00:00:00 2001
++From: Ross Burton <ross.burton@intel.com>
++Date: Fri, 9 Oct 2015 17:50:41 +0100
++Subject: [PATCH] icu: fix install race
++
++The generic recursive target calls target-local so also adding it to the
++dependency list results in races due to install-local being executed twice in
++parallel.  For example, install-manx can fail if the two install processes race
++and one process tries to chown a file that the other process has just deleted.
++
++Also install-manx should be a phony target, and for clarity use $^ instead of $?
++in the install command.
++
++Upstream-Status: Pending
++Signed-off-by: Ross Burton <ross.burton@intel.com>
++
++---
++ source/Makefile.in | 8 ++++----
++ 1 file changed, 4 insertions(+), 4 deletions(-)
++
++diff --git a/Makefile.in b/Makefile.in
++index be9435b..ada20d7 100644
++--- a/Makefile.in
+++++ b/Makefile.in
++@@ -77,7 +77,7 @@ EXTRA_DATA =
++ 
++ ## List of phony targets
++ .PHONY : all all-local all-recursive install install-local install-udata install-udata-files install-udata-dlls		\
++-install-recursive clean clean-local clean-recursive distclean		\
+++install-recursive install-manx clean clean-local clean-recursive distclean		\
++ distclean-local distclean-recursive doc dist dist-local dist-recursive	\
++ check check-local check-recursive clean-recursive-with-twist install-icu \
++ doc install-doc tests icu4j-data icu4j-data-install update-windows-makefiles xcheck-local xcheck-recursive xperf xcheck xperf-recursive \
++@@ -88,9 +88,9 @@ check-exhaustive check-exhaustive-local check-exhaustive-recursive releaseDist
++ 
++ ## List of standard targets
++ all: all-local all-recursive
++-install: install-recursive install-local
+++install: install-recursive
++ clean: clean-recursive-with-twist clean-local
++-distclean : distclean-recursive distclean-local
+++distclean : distclean-recursive
++ dist: dist-recursive
++ check: all check-recursive
++ check-recursive: all
++@@ -357,7 +357,7 @@ config.status: $(srcdir)/configure $(srcdir)/common/unicode/uvernum.h
++ install-manx: $(MANX_FILES)
++ 	$(MKINSTALLDIRS) $(DESTDIR)$(mandir)/man$(SECTION)
++ ifneq ($(MANX_FILES),)
++-	$(INSTALL_DATA) $? $(DESTDIR)$(mandir)/man$(SECTION)
+++	$(INSTALL_DATA) $^ $(DESTDIR)$(mandir)/man$(SECTION)
++ endif
++ 
++ config/%.$(SECTION): $(srcdir)/config/%.$(SECTION).in
+diff -Naur a/poky/meta/recipes-support/icu_66.1/icu/icu-pkgdata-large-cmd.patch b/poky/meta/recipes-support/icu_66.1/icu/icu-pkgdata-large-cmd.patch
+--- a/poky/meta/recipes-support/icu_66.1/icu/icu-pkgdata-large-cmd.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/poky/meta/recipes-support/icu_66.1/icu/icu-pkgdata-large-cmd.patch	2024-08-02 09:23:13.280222683 +0200
+@@ -0,0 +1,49 @@
++pkgdata.cpp: use LARGE_BUFFER_MAX_SIZE for cmd
++
++Use LARGE_BUFFER_MAX_SIZE for cmd rather than SMALL_BUFFER_MAX_SIZE,
++otherwise there was a Segmentation fault error when the command line is
++long, this should be a misplay since other cmd uses
++LARGE_BUFFER_MAX_SIZE.
++
++Upstream-Status: Pending
++
++Signed-off-by: Robert Yang <liezhi.yang@windriver.com>
++Signed-off-by: Jackie Huang <jackie.huang@windriver.com>
++---
++ tools/pkgdata/pkgdata.cpp | 6 +++---
++ 1 file changed, 3 insertions(+), 3 deletions(-)
++
++diff --git a/tools/pkgdata/pkgdata.cpp b/tools/pkgdata/pkgdata.cpp
++index 60167dd..506dd32 100644
++--- a/tools/pkgdata/pkgdata.cpp
+++++ b/tools/pkgdata/pkgdata.cpp
++@@ -1084,7 +1084,7 @@ normal_symlink_mode:
++ 
++ static int32_t pkg_installLibrary(const char *installDir, const char *targetDir, UBool noVersion) {
++     int32_t result = 0;
++-    char cmd[SMALL_BUFFER_MAX_SIZE];
+++    char cmd[LARGE_BUFFER_MAX_SIZE];
++ 
++     sprintf(cmd, "cd %s && %s %s %s%s%s",
++             targetDir,
++@@ -1152,7 +1152,7 @@ static int32_t pkg_installLibrary(const char *installDir, const char *targetDir,
++ 
++ static int32_t pkg_installCommonMode(const char *installDir, const char *fileName) {
++     int32_t result = 0;
++-    char cmd[SMALL_BUFFER_MAX_SIZE] = "";
+++    char cmd[LARGE_BUFFER_MAX_SIZE] = "";
++ 
++     if (!T_FileStream_file_exists(installDir)) {
++         UErrorCode status = U_ZERO_ERROR;
++@@ -1184,7 +1184,7 @@ static int32_t pkg_installCommonMode(const char *installDir, const char *fileNam
++ #endif
++ static int32_t pkg_installFileMode(const char *installDir, const char *srcDir, const char *fileListName) {
++     int32_t result = 0;
++-    char cmd[SMALL_BUFFER_MAX_SIZE] = "";
+++    char cmd[LARGE_BUFFER_MAX_SIZE] = "";
++ 
++     if (!T_FileStream_file_exists(installDir)) {
++         UErrorCode status = U_ZERO_ERROR;
++-- 
++1.9.1
++
+diff -Naur a/poky/meta/recipes-support/icu_66.1/icu_66.1.bb b/poky/meta/recipes-support/icu_66.1/icu_66.1.bb
+--- a/poky/meta/recipes-support/icu_66.1/icu_66.1.bb	1970-01-01 01:00:00.000000000 +0100
++++ b/poky/meta/recipes-support/icu_66.1/icu_66.1.bb	2024-08-02 09:23:13.280222683 +0200
+@@ -0,0 +1,71 @@
++require icu.inc
++
++LIC_FILES_CHKSUM = "file://../LICENSE;md5=a3808a5b70071b07f87ff2205e4d75a0"
++
++def icu_download_version(d):
++    pvsplit = d.getVar('PV').split('.')
++    return pvsplit[0] + "_" + pvsplit[1]
++
++def icu_download_folder(d):
++    pvsplit = d.getVar('PV').split('.')
++    return pvsplit[0] + "-" + pvsplit[1]
++
++ICU_PV = "${@icu_download_version(d)}"
++ICU_FOLDER = "${@icu_download_folder(d)}"
++
++# http://errors.yoctoproject.org/Errors/Details/20486/
++ARM_INSTRUCTION_SET_armv4 = "arm"
++ARM_INSTRUCTION_SET_armv5 = "arm"
++
++BASE_SRC_URI = "https://github.com/unicode-org/icu/releases/download/release-${ICU_FOLDER}/icu4c-${ICU_PV}-src.tgz"
++DATA_SRC_URI = "https://github.com/unicode-org/icu/releases/download/release-${ICU_FOLDER}/icu4c-${ICU_PV}-data.zip"
++SRC_URI = "${BASE_SRC_URI};name=code \
++           ${DATA_SRC_URI};name=data \
++           file://0001-Fix-big-endian-build.patch;patchdir=${WORKDIR} \
++           file://0002-ICU-21175-Add-cnvalias-as-a-dependency-of-misc_res.patch;patchdir=${WORKDIR} \
++           file://filter.json \
++           file://icu-pkgdata-large-cmd.patch \
++           file://fix-install-manx.patch \
++           file://0001-icu-Added-armeb-support.patch \
++           file://CVE-2020-10531.patch \
++           "
++
++SRC_URI_append_class-target = "\
++           file://0001-Disable-LDFLAGSICUDT-for-Linux.patch \
++          "
++SRC_URI[code.sha256sum] = "52a3f2209ab95559c1cf0a14f24338001f389615bf00e2585ef3dbc43ecf0a2e"
++SRC_URI[data.sha256sum] = "8be647f738891d2beb79d48f99077b3499948430eae6f1be112553b15ab0243e"
++
++UPSTREAM_CHECK_REGEX = "icu4c-(?P<pver>\d+(_\d+)+)-src"
++UPSTREAM_CHECK_URI = "https://github.com/unicode-org/icu/releases"
++
++EXTRA_OECONF_append_libc-musl = " ac_cv_func_strtod_l=no"
++
++PACKAGECONFIG ?= ""
++PACKAGECONFIG[make-icudata] = ",,,"
++
++do_make_icudata_class-target () {
++    cd ${S}
++    rm -rf data
++    cp -a ${WORKDIR}/data .
++    ${@bb.utils.contains('PACKAGECONFIG', 'make-icudata', '', 'exit 0', d)}
++    AR='${BUILD_AR}' \
++    CC='${BUILD_CC}' \
++    CPP='${BUILD_CPP}' \
++    CXX='${BUILD_CXX}' \
++    RANLIB='${BUILD_RANLIB}' \
++    CFLAGS='${BUILD_CFLAGS}' \
++    CPPFLAGS='${BUILD_CPPFLAGS}' \
++    CXXFLAGS='${BUILD_CXXFLAGS}' \
++    LDFLAGS='${BUILD_LDFLAGS}' \
++    ICU_DATA_FILTER_FILE=${WORKDIR}/filter.json \
++    ./runConfigureICU Linux --with-data-packaging=archive
++    oe_runmake
++    install -Dm644 ${S}/data/out/icudt${ICU_MAJOR_VER}l.dat ${S}/data/in/icudt${ICU_MAJOR_VER}l.dat
++}
++
++do_make_icudata() {
++    :
++}
++
++addtask make_icudata before do_configure after do_patch
+diff -Naur a/poky/meta/recipes-support/icu_66.1/icu.inc b/poky/meta/recipes-support/icu_66.1/icu.inc
+--- a/poky/meta/recipes-support/icu_66.1/icu.inc	1970-01-01 01:00:00.000000000 +0100
++++ b/poky/meta/recipes-support/icu_66.1/icu.inc	2024-08-02 09:23:13.280222683 +0200
+@@ -0,0 +1,86 @@
++SUMMARY = "International Component for Unicode libraries"
++DESCRIPTION = "The International Component for Unicode (ICU) is a mature, \
++portable set of C/C++ and Java libraries for Unicode support, software \
++internationalization (I18N) and globalization (G11N), giving applications the \
++same results on all platforms."
++HOMEPAGE = "http://site.icu-project.org/"
++
++LICENSE = "ICU"
++DEPENDS = "icu-native"
++DEPENDS_class-native = ""
++
++CVE_PRODUCT = "international_components_for_unicode"
++
++S = "${WORKDIR}/icu/source"
++SPDX_S = "${WORKDIR}/icu"
++STAGING_ICU_DIR_NATIVE = "${STAGING_DATADIR_NATIVE}/${BPN}/${PV}"
++
++BINCONFIG = "${bindir}/icu-config"
++
++ICU_MAJOR_VER = "${@d.getVar('PV').split('.')[0]}"
++
++inherit autotools pkgconfig binconfig multilib_script
++
++MULTILIB_SCRIPTS = "${PN}-dev:${bindir}/icu-config"
++
++# ICU needs the native build directory as an argument to its --with-cross-build option when
++# cross-compiling. Taken the situation that different builds may share a common sstate-cache
++# into consideration, the native build directory needs to be staged.
++EXTRA_OECONF = "--with-cross-build=${STAGING_ICU_DIR_NATIVE}"
++EXTRA_OECONF_class-native = ""
++EXTRA_OECONF_class-nativesdk = "--with-cross-build=${STAGING_ICU_DIR_NATIVE}"
++
++EXTRA_OECONF_append_class-target = "${@oe.utils.conditional('SITEINFO_ENDIANNESS', 'be', ' --with-data-packaging=archive', '', d)}"
++TARGET_CXXFLAGS_append = "${@oe.utils.conditional('SITEINFO_ENDIANNESS', 'be', ' -DICU_DATA_DIR=\\""${datadir}/${BPN}/${PV}\\""', '', d)}"
++
++ASNEEDED = ""
++
++do_compile_prepend_class-target () {
++	# Make sure certain build host references do not end up being compiled
++	# in the image. This only affects libicutu and icu-dbg
++	sed  \
++	    -e 's,DU_BUILD=,DU_BUILD_unused=,g' \
++	    -e '/^CPPFLAGS.*/ s,--sysroot=${STAGING_DIR_TARGET},,g' \
++	    -i ${B}/tools/toolutil/Makefile
++}
++
++PREPROCESS_RELOCATE_DIRS = "${datadir}/${BPN}/${PV}"
++do_install_append_class-native() {
++	mkdir -p ${D}/${STAGING_ICU_DIR_NATIVE}/config
++	cp -r ${B}/config/icucross.mk ${D}/${STAGING_ICU_DIR_NATIVE}/config
++	cp -r ${B}/config/icucross.inc ${D}/${STAGING_ICU_DIR_NATIVE}/config
++	cp -r ${B}/lib ${D}/${STAGING_ICU_DIR_NATIVE}
++	cp -r ${B}/bin ${D}/${STAGING_ICU_DIR_NATIVE}
++	cp -r ${B}/tools ${D}/${STAGING_ICU_DIR_NATIVE}
++}
++
++do_install_append_class-target() {
++    # The native pkgdata can not generate the correct data file.
++    # Use icupkg to re-generate it.
++    if [ "${SITEINFO_ENDIANNESS}" = "be" ] ; then
++        rm -f ${D}/${datadir}/${BPN}/${PV}/icudt${ICU_MAJOR_VER}b.dat
++	if [ -f ${S}/data/in/icudt${ICU_MAJOR_VER}l.dat ]; then
++		icupkg -tb ${S}/data/in/icudt${ICU_MAJOR_VER}l.dat ${D}/${datadir}/${BPN}/${PV}/icudt${ICU_MAJOR_VER}b.dat
++	fi
++    fi
++	
++	# Remove build host references...
++	sed -i  \
++	    -e 's,--sysroot=${STAGING_DIR_TARGET},,g' \
++	    -e 's|${DEBUG_PREFIX_MAP}||g' \
++	    -e 's:${HOSTTOOLS_DIR}/::g' \
++	    ${D}/${bindir}/icu-config ${D}/${libdir}/${BPN}/${PV}/Makefile.inc \
++	    ${D}/${libdir}/${BPN}/${PV}/pkgdata.inc
++}
++
++PACKAGES =+ "libicudata libicuuc libicui18n libicutu libicuio"
++
++FILES_${PN}-dev += "${libdir}/${BPN}/"
++
++FILES_libicudata = "${libdir}/libicudata.so.*"
++FILES_libicuuc = "${libdir}/libicuuc.so.*"
++FILES_libicui18n = "${libdir}/libicui18n.so.*"
++FILES_libicutu = "${libdir}/libicutu.so.*"
++FILES_libicuio = "${libdir}/libicuio.so.*"
++
++BBCLASSEXTEND = "native nativesdk"
+diff -Naur a/poky/meta/recipes-support/icu_70.1/icu/0001-Disable-LDFLAGSICUDT-for-Linux.patch b/poky/meta/recipes-support/icu_70.1/icu/0001-Disable-LDFLAGSICUDT-for-Linux.patch
+--- a/poky/meta/recipes-support/icu_70.1/icu/0001-Disable-LDFLAGSICUDT-for-Linux.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/poky/meta/recipes-support/icu_70.1/icu/0001-Disable-LDFLAGSICUDT-for-Linux.patch	2024-08-02 09:23:13.280222683 +0200
+@@ -0,0 +1,28 @@
++From 0c82d6aa02c08e41b13c83b14782bd7024e25d59 Mon Sep 17 00:00:00 2001
++From: Khem Raj <raj.khem@gmail.com>
++Date: Sat, 15 Feb 2014 21:06:42 +0000
++Subject: [PATCH] Disable LDFLAGSICUDT for Linux
++
++Upstream-Status: Inappropriate [ OE Configuration ]
++
++Signed-off-by: Khem Raj <raj.khem@gmail.com>
++---
++ source/config/mh-linux |    2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/config/mh-linux b/config/mh-linux
++index 366f0cc..2689aab 100644
++--- a/config/mh-linux
+++++ b/config/mh-linux
++@@ -21,7 +21,7 @@ LD_RPATH= -Wl,-zorigin,-rpath,'$$'ORIGIN
++ LD_RPATH_PRE = -Wl,-rpath,
++ 
++ ## These are the library specific LDFLAGS
++-LDFLAGSICUDT=-nodefaultlibs -nostdlib
+++# LDFLAGSICUDT=-nodefaultlibs -nostdlib
++ 
++ ## Compiler switch to embed a library name
++ # The initial tab in the next line is to prevent icu-config from reading it.
++-- 
++1.7.10.4
++
+diff -Naur a/poky/meta/recipes-support/icu_70.1/icu/0001-icu-Added-armeb-support.patch b/poky/meta/recipes-support/icu_70.1/icu/0001-icu-Added-armeb-support.patch
+--- a/poky/meta/recipes-support/icu_70.1/icu/0001-icu-Added-armeb-support.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/poky/meta/recipes-support/icu_70.1/icu/0001-icu-Added-armeb-support.patch	2024-08-02 09:23:13.280222683 +0200
+@@ -0,0 +1,28 @@
++From e3c25af4b40d64f098e7b8ae5a91fdc3c90163c4 Mon Sep 17 00:00:00 2001
++From: Lei Maohui <leimaohui@cn.fujitsu.com>
++Date: Wed, 8 May 2019 14:42:30 +0900
++Subject: [PATCH] icu: Added armeb support.
++
++Make icu support arm32 BE.
++
++Upstream-Status: Pending
++
++Signed-off-by: Lei Maohui <leimaohui@cn.fujitsu.com>
++
++---
++ i18n/double-conversion-utils.h | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/source/i18n/double-conversion-utils.h b/source/i18n/double-conversion-utils.h
++index 7f23e0a..7f89094 100644
++--- a/i18n/double-conversion-utils.h
+++++ b/i18n/double-conversion-utils.h
++@@ -115,7 +115,7 @@ int main(int argc, char** argv) {
++ //
++ // If it prints "correct" then the architecture should be here, in the "correct" section.
++ #if defined(_M_X64) || defined(__x86_64__) || \
++-    defined(__ARMEL__) || defined(__avr32__) || defined(_M_ARM) || defined(_M_ARM64) || \
+++    defined(__arm__) || defined(__avr32__) || defined(_M_ARM) || defined(_M_ARM64) || \
++     defined(__hppa__) || defined(__ia64__) || \
++     defined(__mips__) || \
++     defined(__loongarch__) || \
+diff -Naur a/poky/meta/recipes-support/icu_70.1/icu/filter.json b/poky/meta/recipes-support/icu_70.1/icu/filter.json
+--- a/poky/meta/recipes-support/icu_70.1/icu/filter.json	1970-01-01 01:00:00.000000000 +0100
++++ b/poky/meta/recipes-support/icu_70.1/icu/filter.json	2024-08-02 09:23:13.280222683 +0200
+@@ -0,0 +1,2 @@
++{
++}
+diff -Naur a/poky/meta/recipes-support/icu_70.1/icu/fix-install-manx.patch b/poky/meta/recipes-support/icu_70.1/icu/fix-install-manx.patch
+--- a/poky/meta/recipes-support/icu_70.1/icu/fix-install-manx.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/poky/meta/recipes-support/icu_70.1/icu/fix-install-manx.patch	2024-08-02 09:23:13.280222683 +0200
+@@ -0,0 +1,54 @@
++From a6ddabc8cadb76bfe2d2e374a6702442cfe51cce Mon Sep 17 00:00:00 2001
++From: Ross Burton <ross.burton@intel.com>
++Date: Fri, 9 Oct 2015 17:50:41 +0100
++Subject: [PATCH] icu: fix install race
++
++The generic recursive target calls target-local so also adding it to the
++dependency list results in races due to install-local being executed twice in
++parallel.  For example, install-manx can fail if the two install processes race
++and one process tries to chown a file that the other process has just deleted.
++
++Also install-manx should be a phony target, and for clarity use $^ instead of $?
++in the install command.
++
++Upstream-Status: Pending
++Signed-off-by: Ross Burton <ross.burton@intel.com>
++
++---
++ source/Makefile.in | 8 ++++----
++ 1 file changed, 4 insertions(+), 4 deletions(-)
++
++diff --git a/Makefile.in b/Makefile.in
++index be9435b..ada20d7 100644
++--- a/Makefile.in
+++++ b/Makefile.in
++@@ -77,7 +77,7 @@ EXTRA_DATA =
++ 
++ ## List of phony targets
++ .PHONY : all all-local all-recursive install install-local install-udata install-udata-files install-udata-dlls		\
++-install-recursive clean clean-local clean-recursive distclean		\
+++install-recursive install-manx clean clean-local clean-recursive distclean		\
++ distclean-local distclean-recursive doc dist dist-local dist-recursive	\
++ check check-local check-recursive clean-recursive-with-twist install-icu \
++ doc install-doc tests icu4j-data icu4j-data-install update-windows-makefiles xcheck-local xcheck-recursive xperf xcheck xperf-recursive \
++@@ -88,9 +88,9 @@ check-exhaustive check-exhaustive-local check-exhaustive-recursive releaseDist
++ 
++ ## List of standard targets
++ all: all-local all-recursive
++-install: install-recursive install-local
+++install: install-recursive
++ clean: clean-recursive-with-twist clean-local
++-distclean : distclean-recursive distclean-local
+++distclean : distclean-recursive
++ dist: dist-recursive
++ check: all check-recursive
++ check-recursive: all
++@@ -357,7 +357,7 @@ config.status: $(srcdir)/configure $(srcdir)/common/unicode/uvernum.h
++ install-manx: $(MANX_FILES)
++ 	$(MKINSTALLDIRS) $(DESTDIR)$(mandir)/man$(SECTION)
++ ifneq ($(MANX_FILES),)
++-	$(INSTALL_DATA) $? $(DESTDIR)$(mandir)/man$(SECTION)
+++	$(INSTALL_DATA) $^ $(DESTDIR)$(mandir)/man$(SECTION)
++ endif
++ 
++ config/%.$(SECTION): $(srcdir)/config/%.$(SECTION).in
+diff -Naur a/poky/meta/recipes-support/icu_70.1/icu_70.1.bb b/poky/meta/recipes-support/icu_70.1/icu_70.1.bb
+--- a/poky/meta/recipes-support/icu_70.1/icu_70.1.bb	1970-01-01 01:00:00.000000000 +0100
++++ b/poky/meta/recipes-support/icu_70.1/icu_70.1.bb	2024-08-02 09:23:13.280222683 +0200
+@@ -0,0 +1,150 @@
++SUMMARY = "International Component for Unicode libraries"
++DESCRIPTION = "The International Component for Unicode (ICU) is a mature, \
++portable set of C/C++ and Java libraries for Unicode support, software \
++internationalization (I18N) and globalization (G11N), giving applications the \
++same results on all platforms."
++HOMEPAGE = "http://site.icu-project.org/"
++
++LICENSE = "ICU"
++DEPENDS = "icu-native autoconf-archive"
++DEPENDS_class-native = "autoconf-archive-native"
++
++CVE_PRODUCT = "international_components_for_unicode"
++
++S = "${WORKDIR}/icu/source"
++SPDX_S = "${WORKDIR}/icu"
++STAGING_ICU_DIR_NATIVE = "${STAGING_DATADIR_NATIVE}/${BPN}/${PV}"
++
++BINCONFIG = "${bindir}/icu-config"
++
++ICU_MAJOR_VER = "${@d.getVar('PV').split('.')[0]}"
++
++inherit autotools pkgconfig binconfig multilib_script
++
++MULTILIB_SCRIPTS = "${PN}-dev:${bindir}/icu-config"
++
++# ICU needs the native build directory as an argument to its --with-cross-build option when
++# cross-compiling. Taken the situation that different builds may share a common sstate-cache
++# into consideration, the native build directory needs to be staged.
++EXTRA_OECONF = "--with-cross-build=${STAGING_ICU_DIR_NATIVE}"
++EXTRA_OECONF_class-native = ""
++EXTRA_OECONF_class-nativesdk = "--with-cross-build=${STAGING_ICU_DIR_NATIVE}"
++
++EXTRA_OECONF_append_class-target = "${@oe.utils.conditional('SITEINFO_ENDIANNESS', 'be', ' --with-data-packaging=archive', '', d)}"
++TARGET_CXXFLAGS_append = "${@oe.utils.conditional('SITEINFO_ENDIANNESS', 'be', ' -DICU_DATA_DIR=\\""${datadir}/${BPN}/${PV}\\""', '', d)}"
++
++ASNEEDED = ""
++
++do_compile_prepend_class-target () {
++	# Make sure certain build host references do not end up being compiled
++	# in the image. This only affects libicutu and icu-dbg
++	sed  \
++	    -e 's,DU_BUILD=,DU_BUILD_unused=,g' \
++	    -e '/^CPPFLAGS.*/ s,--sysroot=${STAGING_DIR_TARGET},,g' \
++	    -i ${B}/tools/toolutil/Makefile
++}
++
++PREPROCESS_RELOCATE_DIRS = "${datadir}/${BPN}/${PV}"
++do_install_append_class-native() {
++	mkdir -p ${D}/${STAGING_ICU_DIR_NATIVE}/config
++	cp -r ${B}/config/icucross.mk ${D}/${STAGING_ICU_DIR_NATIVE}/config
++	cp -r ${B}/config/icucross.inc ${D}/${STAGING_ICU_DIR_NATIVE}/config
++	cp -r ${B}/lib ${D}/${STAGING_ICU_DIR_NATIVE}
++	cp -r ${B}/bin ${D}/${STAGING_ICU_DIR_NATIVE}
++	cp -r ${B}/tools ${D}/${STAGING_ICU_DIR_NATIVE}
++}
++
++do_install_append_class-target() {
++    # The native pkgdata can not generate the correct data file.
++    # Use icupkg to re-generate it.
++    if [ "${SITEINFO_ENDIANNESS}" = "be" ] ; then
++        rm -f ${D}/${datadir}/${BPN}/${PV}/icudt${ICU_MAJOR_VER}b.dat
++        icupkg -tb ${S}/data/in/icudt${ICU_MAJOR_VER}l.dat ${D}/${datadir}/${BPN}/${PV}/icudt${ICU_MAJOR_VER}b.dat
++    fi
++	
++	# Remove build host references...
++	sed -i  \
++	    -e 's,--sysroot=${STAGING_DIR_TARGET},,g' \
++	    -e 's|${DEBUG_PREFIX_MAP}||g' \
++	    -e 's:${HOSTTOOLS_DIR}/::g' \
++	    ${D}/${bindir}/icu-config ${D}/${libdir}/${BPN}/${PV}/Makefile.inc \
++	    ${D}/${libdir}/${BPN}/${PV}/pkgdata.inc
++}
++
++PACKAGES =+ "libicudata libicuuc libicui18n libicutu libicuio"
++
++FILES_${PN}-dev += "${libdir}/${BPN}/"
++
++FILES_libicudata = "${libdir}/libicudata.so.*"
++FILES_libicuuc = "${libdir}/libicuuc.so.*"
++FILES_libicui18n = "${libdir}/libicui18n.so.*"
++FILES_libicutu = "${libdir}/libicutu.so.*"
++FILES_libicuio = "${libdir}/libicuio.so.*"
++
++BBCLASSEXTEND = "native nativesdk"
++
++LIC_FILES_CHKSUM = "file://../LICENSE;md5=dc9d616e558490c389609a0e8b81ae6d"
++
++def icu_download_version(d):
++    pvsplit = d.getVar('PV').split('.')
++    return pvsplit[0] + "_" + pvsplit[1]
++
++def icu_download_folder(d):
++    pvsplit = d.getVar('PV').split('.')
++    return pvsplit[0] + "-" + pvsplit[1]
++
++ICU_PV = "${@icu_download_version(d)}"
++ICU_FOLDER = "${@icu_download_folder(d)}"
++
++# http://errors.yoctoproject.org/Errors/Details/20486/
++ARM_INSTRUCTION_SET_armv4 = "arm"
++ARM_INSTRUCTION_SET_armv5 = "arm"
++
++BASE_SRC_URI = "https://github.com/unicode-org/icu/releases/download/release-${ICU_FOLDER}/icu4c-${ICU_PV}-src.tgz"
++DATA_SRC_URI = "https://github.com/unicode-org/icu/releases/download/release-${ICU_FOLDER}/icu4c-${ICU_PV}-data.zip"
++SRC_URI = "${BASE_SRC_URI};name=code \
++           ${DATA_SRC_URI};name=data \
++           file://filter.json \
++           file://fix-install-manx.patch \
++           file://0001-icu-Added-armeb-support.patch \
++           "
++
++SRC_URI_append_class-target = "\
++           file://0001-Disable-LDFLAGSICUDT-for-Linux.patch \
++          "
++SRC_URI[code.sha256sum] = "8d205428c17bf13bb535300669ed28b338a157b1c01ae66d31d0d3e2d47c3fd5"
++SRC_URI[data.sha256sum] = "c72723ddba3300ffb231d6b09e2a728ea6e89de10ed5927f74bacbd77042336e"
++
++UPSTREAM_CHECK_REGEX = "icu4c-(?P<pver>\d+(_\d+)+)-src"
++UPSTREAM_CHECK_URI = "https://github.com/unicode-org/icu/releases"
++
++EXTRA_OECONF_append_libc-musl = " ac_cv_func_strtod_l=no"
++
++PACKAGECONFIG ?= ""
++PACKAGECONFIG[make-icudata] = ",,,"
++
++do_make_icudata_class-target () {
++    ${@bb.utils.contains('PACKAGECONFIG', 'make-icudata', '', 'exit 0', d)}
++    cd ${S}
++    rm -rf data
++    cp -a ${WORKDIR}/data .
++    AR='${BUILD_AR}' \
++    CC='${BUILD_CC}' \
++    CPP='${BUILD_CPP}' \
++    CXX='${BUILD_CXX}' \
++    RANLIB='${BUILD_RANLIB}' \
++    CFLAGS='${BUILD_CFLAGS}' \
++    CPPFLAGS='${BUILD_CPPFLAGS}' \
++    CXXFLAGS='${BUILD_CXXFLAGS}' \
++    LDFLAGS='${BUILD_LDFLAGS}' \
++    ICU_DATA_FILTER_FILE=${WORKDIR}/filter.json \
++    ./runConfigureICU Linux --with-data-packaging=archive
++    oe_runmake
++    install -Dm644 ${S}/data/out/icudt${ICU_MAJOR_VER}l.dat ${S}/data/in/icudt${ICU_MAJOR_VER}l.dat
++}
++
++do_make_icudata() {
++    :
++}
++
++addtask make_icudata before do_configure after do_patch do_prepare_recipe_sysroot
+diff -Naur a/poky/meta/recipes-support/libical/libical/0002_add_TRUE_FALSE_to_libical-3.0.7_icalrecur.h.patch b/poky/meta/recipes-support/libical/libical/0002_add_TRUE_FALSE_to_libical-3.0.7_icalrecur.h.patch
+--- a/poky/meta/recipes-support/libical/libical/0002_add_TRUE_FALSE_to_libical-3.0.7_icalrecur.h.patch	1970-01-01 01:00:00.000000000 +0100
++++ b/poky/meta/recipes-support/libical/libical/0002_add_TRUE_FALSE_to_libical-3.0.7_icalrecur.h.patch	2024-08-02 09:23:13.276222621 +0200
+@@ -0,0 +1,20 @@
++--- a/src/libical/icalrecur.h	2024-06-19 14:50:38.329959097 +0200
+++++ b/src/libical/icalrecur.h	2024-06-19 14:50:38.329959097 +0200
++@@ -70,6 +70,17 @@
++ #include "icalarray.h"
++ #include "icaltime.h"
++ 
+++
+++#ifndef FALSE
+++#define FALSE   (0)
+++#endif
+++
+++
+++#ifndef TRUE
+++#define TRUE    (!FALSE)
+++#endif
+++
+++
++ /*
++  * Recurrence enumerations
++  */
+diff -Naur a/poky/meta/recipes-support/libical/libical_3.0.7.bb b/poky/meta/recipes-support/libical/libical_3.0.7.bb
+--- a/poky/meta/recipes-support/libical/libical_3.0.7.bb	2024-06-21 09:02:06.000000000 +0200
++++ b/poky/meta/recipes-support/libical/libical_3.0.7.bb	2024-08-02 09:23:13.276222621 +0200
+@@ -15,6 +15,7 @@
+ SRC_URI = " \
+     https://github.com/${BPN}/${BPN}/releases/download/v${PV}/${BP}.tar.gz \
+     file://0001-Use-our-hand-build-native-src-generator.patch \
++    file://0002_add_TRUE_FALSE_to_libical-3.0.7_icalrecur.h.patch \
+ "
+ SRC_URI[md5sum] = "8a5d07a7fba9e73a85e67f76258bf042"
+ SRC_URI[sha256sum] = "0abe66df1ea826e57db7f281c704ede834c84139012e6c686ea7adafd4e763fc"


### PR DESCRIPTION
# Justification

For improved compatibility with Edge Impulse, meta-rzboard has been extended to support Node 18 as the default Node for RZboard. Node 18 was picked because It's the best balance for time invested. Technically, we'd prefer to be on Node 20.x+. In the future, when RZBoard extends beyond Dunfell, we will drop these patches in preference of node 20.x or greater.

## Changes

- Integrate Node 18 into environment setup via patchfile and bbappend.
- Extend the automations in create_yocto_rz_src.sh setup script
- Extend / improve logging in create_yocto_rz_src.sh
- Applied best practice improvements / cleanup to create_yocto_rz_src.sh

## Verification

I verified all of these changes by building in an Ubuntu 20.04 container, flashing, and manually testing my RZBoard.

> [!IMPORTANT]
> The script clones rzboard_dunfell_5.10.201 because that will be the most appropriate branch after this pull request is merged. Modify `create_yocto_rz_src.sh` by doing the following replacement`git clone https://github.com/Avnet/meta-rzboard.git -b rzboard_dunfell_5.10.201` -> `git clone https://github.com/Avnet/meta-rzboard.git -b feature/node_18_support` for the script to run successfully.


## Known-issues

- During verification of this build, it was thought there was a Node networking issue. However, it appears there was a regression in Edge Impulse' v1.9.0 release of their npm based utility: https://www.npmjs.com/package/edge-impulse-linux edge-impulse-linux. The workaround for that issue is to use Edge Impulse version(s) <= v1.8.10. IE) `npm install edge-impulse-linux@1.8.10 -g --unsafe-perm`
- Some _RZBoard demo launcher_ dependencies were incompatible with this version bump. Seeing as there are other more recent demos, the demo launcher will no longer be enabled by default. Maintenance of the demo launcher application would be necessary to enable it again.